### PR TITLE
Add StudentCourse feature: view course & classmates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -367,3 +367,6 @@ FodyWeavers.xsd
 
 # Token storage (contains sensitive authentication tokens)
 **/App_Data/
+/REAL_BACKLOG.md
+/.gitignore
+/.gitignore

--- a/LMS.API/Extensions/ServiceExtensions.cs
+++ b/LMS.API/Extensions/ServiceExtensions.cs
@@ -1,4 +1,4 @@
-﻿using LMS.Infractructure.Data;
+using LMS.Infractructure.Data;
 using LMS.Infractructure.Repositories;
 using LMS.Presentation;
 using LMS.Services;
@@ -110,5 +110,7 @@ public static class ServiceExtensions
         // Submission Service
         services.AddScoped<ISubmissionService, SubmissionService>();
         services.AddScoped(provider => new Lazy<ISubmissionService>(() => provider.GetRequiredService<ISubmissionService>()));
+
+        services.AddScoped<IStudentCourseService, StudentCourseService>();
     }
 }

--- a/LMS.Presentation/Controllers/StudentCourseController.cs
+++ b/LMS.Presentation/Controllers/StudentCourseController.cs
@@ -1,0 +1,64 @@
+using LMS.Shared.DTOs.Course;
+using LMS.Shared.DTOs.User;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Service.Contracts;
+using Swashbuckle.AspNetCore.Annotations;
+using System.Security.Claims;
+
+namespace LMS.Presentation.Controllers;
+
+[Route("api/studentcourse")]
+[ApiController]
+[Authorize]
+public class StudentCourseController : ControllerBase
+{
+    private readonly IStudentCourseService studentCourseService;
+
+    public StudentCourseController(IStudentCourseService studentCourseService)
+    {
+        this.studentCourseService = studentCourseService;
+    }
+
+    [HttpGet("mycourse")]
+    [SwaggerOperation(
+        Summary = "Get current student's enrolled course",
+        Description = "Returns the course the authenticated student is enrolled in (from ApplicationUser.CourseId). Requires JWT.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Course found", typeof(CourseDto))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated")]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "User is not a student, has no course, or course not found")]
+    public async Task<ActionResult<CourseDto>> GetMyCourse()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrWhiteSpace(userId))
+            return Unauthorized();
+
+        var course = await studentCourseService.GetStudentCourseAsync(userId);
+        if (course is null)
+            return NotFound();
+
+        return Ok(course);
+    }
+
+    [HttpGet("classmates")]
+    [SwaggerOperation(
+        Summary = "Get classmates in the same course",
+        Description = "Returns other students enrolled in the same course as the current user. Current user is excluded.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "List of classmates", typeof(IEnumerable<StudentDto>))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated")]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Cannot resolve student's course")]
+    public async Task<ActionResult<IReadOnlyList<StudentDto>>> GetClassmates()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrWhiteSpace(userId))
+            return Unauthorized();
+
+        var course = await studentCourseService.GetStudentCourseAsync(userId);
+        if (course is null)
+            return NotFound();
+
+        var classmates = await studentCourseService.GetCourseClassmatesAsync(course.Id, userId);
+        return Ok(classmates);
+    }
+}

--- a/LMS.Services/StudentCourseService.cs
+++ b/LMS.Services/StudentCourseService.cs
@@ -1,0 +1,54 @@
+using Domain.Models.Entities;
+using LMS.Shared.DTOs.Course;
+using LMS.Shared.DTOs.User;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Service.Contracts;
+
+namespace LMS.Services;
+
+public class StudentCourseService : IStudentCourseService
+{
+    private const string StudentRole = "Student";
+
+    private readonly UserManager<ApplicationUser> userManager;
+    private readonly ICourseService courseService;
+
+    public StudentCourseService(UserManager<ApplicationUser> userManager, ICourseService courseService)
+    {
+        this.userManager = userManager;
+        this.courseService = courseService;
+    }
+
+    public async Task<CourseDto?> GetStudentCourseAsync(string userId)
+    {
+        var user = await userManager.FindByIdAsync(userId);
+        if (user is null)
+            return null;
+
+        if (!await userManager.IsInRoleAsync(user, StudentRole))
+            return null;
+
+        if (user.CourseId is not int courseId)
+            return null;
+
+        return await courseService.GetCourseByIdAsync(courseId);
+    }
+
+    public async Task<IReadOnlyList<StudentDto>> GetCourseClassmatesAsync(int courseId, string excludeUserId)
+    {
+        var users = await userManager.Users
+            .AsNoTracking()
+            .Where(u => u.CourseId == courseId && u.Id != excludeUserId)
+            .ToListAsync();
+
+        return users
+            .Select(u => new StudentDto
+            {
+                Id = u.Id,
+                Name = u.UserName ?? string.Empty,
+                Email = u.Email ?? string.Empty
+            })
+            .ToList();
+    }
+}

--- a/LMS.Shared/DTOs/User/StudentDto.cs
+++ b/LMS.Shared/DTOs/User/StudentDto.cs
@@ -1,0 +1,11 @@
+namespace LMS.Shared.DTOs.User;
+
+/// <summary>
+/// Student row for classmates list (Id, display name, email).
+/// </summary>
+public sealed class StudentDto
+{
+    public required string Id { get; init; }
+    public required string Name { get; init; }
+    public required string Email { get; init; }
+}

--- a/Service.Contracts/IStudentCourseService.cs
+++ b/Service.Contracts/IStudentCourseService.cs
@@ -1,0 +1,11 @@
+using LMS.Shared.DTOs.Course;
+using LMS.Shared.DTOs.User;
+
+namespace Service.Contracts;
+
+public interface IStudentCourseService
+{
+    Task<CourseDto?> GetStudentCourseAsync(string userId);
+
+    Task<IReadOnlyList<StudentDto>> GetCourseClassmatesAsync(int courseId, string excludeUserId);
+}


### PR DESCRIPTION
Uppgift | Implementering
-- | --
1.1 | LMS.Presentation/Controllers/StudentCourseController.cs — [ApiController], [Route("api/studentcourse")], [Authorize]
1.2 | GET /api/studentcourse/mycourse — userId från JWT, svar CourseDto, 404 om användaren inte är student / saknar CourseId / kursen hittas inte
1.3 | CourseDto finns redan i LMS.Shared/DTOs/Course/CourseDto.cs (Id, Name, Description, StartDate, StudentCount + övriga fält). StudentDto — ny fil LMS.Shared/DTOs/User/StudentDto.cs (Id, Name, Email)
1.4 | GET /api/studentcourse/classmates — lista StudentDto, nuvarande användare är utelämnad
1.5 | LMS.Services/StudentCourseService.cs + Service.Contracts/IStudentCourseService.cs — GetStudentCourseAsync, GetCourseClassmatesAsync (roll Student, UserManager + ICourseService)
1.6 | Registrering i LMS.API/Extensions/ServiceExtensions.cs: AddScoped<IStudentCourseService, StudentCourseService>(); styrenheten får tjänsten via konstruktorn
1.7 | Test i Postman — hos dig: inloggning → JWT → två GET-anrop (401 utan token, 404 för icke-student / utan kurs)
1.8 | På metoderna finns SwaggerOperation / SwaggerResponse — i Swagger UI ska endpoints visas med scheman

Obs om data: svaren beror på ApplicationUser.CourseId och rollen Student (seed i LMS.API/Services/DataSeedHostingService.cs). Om användaren inte har någon inskrivning blir det 404 på mycourse och på classmates.