### PR TITLE
Add student course page, API client, and config validation(#64)#134

### DIFF
--- a/LMS.API/Extensions/AuthServiceExtension.cs
+++ b/LMS.API/Extensions/AuthServiceExtension.cs
@@ -1,4 +1,4 @@
-﻿using Domain.Models.Configurations;
+using Domain.Models.Configurations;
 using LMS.Infractructure.Data;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
@@ -23,6 +23,12 @@ public static class AuthServiceExtension
                          .GetSection(JwtSettings.Section)
                          .Get<JwtSettings>()
                          ?? throw new InvalidOperationException("JwtSettings section is missing or invalid.");
+
+        if (string.IsNullOrWhiteSpace(jwtSettings.SecretKey))
+        {
+            throw new InvalidOperationException(
+                "JwtSettings:SecretKey is missing or empty. Add it to appsettings (e.g. appsettings.Development.json), user secrets: JwtSettings:SecretKey, or environment variables.");
+        }
 
         services.AddOptions<JwtSettings>()
                         .Bind(configuration.GetSection(JwtSettings.Section))

--- a/LMS.API/appsettings.Development.json
+++ b/LMS.API/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "JwtSettings": {
+    "SecretKey": "LocalDevelopmentOnly_SymmetricKey_MustBeLongEnough_UseUserSecretsOrEnvInProduction_1234567890"
   }
 }

--- a/LMS.Blazor/LMS.Blazor.Client/Layout/NavMenu.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Layout/NavMenu.razor
@@ -1,4 +1,4 @@
-﻿@implements IDisposable
+@implements IDisposable
 @inject NavigationManager NavigationManager
 @using Microsoft.AspNetCore.Components.Authorization
 
@@ -108,6 +108,13 @@
                         <NavLink class="nav-link" href="/student">
                             <span class="bi bi-grid-nav-menu" aria-hidden="true"></span>
                             Dashboard
+                        </NavLink>
+                    </div>
+
+                    <div class="nav-item">
+                        <NavLink class="nav-link" href="/student/course">
+                            <span class="bi bi-mortarboard" aria-hidden="true"></span>
+                            My course
                         </NavLink>
                     </div>
 

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/StudentCourse.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/StudentCourse.razor
@@ -1,0 +1,126 @@
+@page "/student/course"
+@attribute [Authorize(Roles = "Student")]
+@using System.Net.Http
+@using LMS.Shared.DTOs.Course
+@using LMS.Shared.DTOs.User
+@inject IStudentCourseClientService StudentCourseClient
+
+<PageTitle>My course</PageTitle>
+
+<div class="container-fluid py-4">
+    <h2 class="mb-4">My course</h2>
+
+    @if (isLoading)
+    {
+        <div class="text-center py-5">
+            <div class="spinner-border text-primary" role="status"></div>
+            <p class="mt-2 text-muted">Loading...</p>
+        </div>
+    }
+    else if (!string.IsNullOrEmpty(errorMessage))
+    {
+        <div class="alert alert-danger">
+            <p class="mb-0">@errorMessage</p>
+            <button type="button" class="btn btn-outline-danger btn-sm mt-2" @onclick="LoadAsync">Retry</button>
+        </div>
+    }
+    else if (course is null)
+    {
+        <div class="alert alert-info">
+            No enrolled course found. You may not be assigned to a course, or your account is not in the Student role for API access.
+        </div>
+    }
+    else
+    {
+        <div class="card mb-4">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h5 class="mb-0">@course.Name</h5>
+                <span class="badge bg-secondary">@course.StudentCount students</span>
+            </div>
+            <div class="card-body">
+                <p class="text-muted small mb-1">Description</p>
+                <p>@course.Description</p>
+                <div class="row mt-3">
+                    <div class="col-md-4">
+                        <p class="text-muted small mb-1">Start</p>
+                        <p>@course.StartDate.ToString("yyyy-MM-dd")</p>
+                    </div>
+                    <div class="col-md-4">
+                        <p class="text-muted small mb-1">Modules</p>
+                        <p>@course.ModuleCount</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header">
+                <h5 class="mb-0">Classmates</h5>
+            </div>
+            <div class="card-body p-0">
+                @if (classmates.Count == 0)
+                {
+                    <p class="p-3 mb-0 text-muted">No other students in this course.</p>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-striped mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Email</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var s in classmates)
+                                {
+                                    <tr>
+                                        <td>@s.Name</td>
+                                        <td>@s.Email</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    private bool isLoading = true;
+    private string? errorMessage;
+    private CourseDto? course;
+    private IReadOnlyList<StudentDto> classmates = Array.Empty<StudentDto>();
+
+    protected override Task OnInitializedAsync() => LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        isLoading = true;
+        errorMessage = null;
+        course = null;
+        classmates = Array.Empty<StudentDto>();
+
+        try
+        {
+            course = await StudentCourseClient.GetMyCourseAsync();
+            if (course is not null)
+                classmates = await StudentCourseClient.GetClassmatesAsync();
+        }
+        catch (HttpRequestException ex)
+        {
+            errorMessage = $"Could not reach the API: {ex.Message}";
+        }
+        catch (Exception ex)
+        {
+            errorMessage = ex.Message;
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Program.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Program.cs
@@ -20,6 +20,7 @@ internal class Program
 
         builder.Services.AddScoped<IApiService, ClientApiService>();
         builder.Services.AddScoped<ICourseService, CourseService>();
+        builder.Services.AddScoped<IStudentCourseClientService, StudentCourseClientService>();
 
         await builder.Build().RunAsync();
     }

--- a/LMS.Blazor/LMS.Blazor.Client/Services/ClientApiService.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Services/ClientApiService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components;
+using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 
@@ -25,6 +26,16 @@ public class ClientApiService : IApiService
     public async Task<T?> GetAsync<T>(string endpoint, CancellationToken ct = default)
     {
         var response = await _httpClient.GetAsync($"api/proxy/{endpoint}", ct);
+        HandleUnauthorized(response);
+        response.EnsureSuccessStatusCode();
+        return await DeserializeAsync<T>(response, ct);
+    }
+
+    public async Task<T?> GetAllowNotFoundAsync<T>(string endpoint, CancellationToken ct = default)
+    {
+        var response = await _httpClient.GetAsync($"api/proxy/{endpoint.TrimStart('/')}", ct);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return default;
         HandleUnauthorized(response);
         response.EnsureSuccessStatusCode();
         return await DeserializeAsync<T>(response, ct);

--- a/LMS.Blazor/LMS.Blazor.Client/Services/IApiService.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Services/IApiService.cs
@@ -1,8 +1,12 @@
-﻿namespace LMS.Blazor.Client.Services;
+namespace LMS.Blazor.Client.Services;
 
 public interface IApiService
 {
     Task<T?> GetAsync<T>(string endpoint, CancellationToken ct = default);
+
+    /// <summary>Returns default (null) when API responds with 404.</summary>
+    Task<T?> GetAllowNotFoundAsync<T>(string endpoint, CancellationToken ct = default);
+
     Task<T?> PostAsync<T>(string endpoint, object body, CancellationToken ct = default);
     Task<T?> PutAsync<T>(string endpoint, object body, CancellationToken ct = default);
     Task<bool> DeleteAsync(string endpoint, CancellationToken ct = default);

--- a/LMS.Blazor/LMS.Blazor.Client/Services/IStudentCourseClientService.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Services/IStudentCourseClientService.cs
@@ -1,0 +1,11 @@
+using LMS.Shared.DTOs.Course;
+using LMS.Shared.DTOs.User;
+
+namespace LMS.Blazor.Client.Services;
+
+public interface IStudentCourseClientService
+{
+    Task<CourseDto?> GetMyCourseAsync(CancellationToken ct = default);
+
+    Task<IReadOnlyList<StudentDto>> GetClassmatesAsync(CancellationToken ct = default);
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Services/StudentCourseClientService.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Services/StudentCourseClientService.cs
@@ -1,0 +1,26 @@
+using LMS.Shared.DTOs.Course;
+using LMS.Shared.DTOs.User;
+
+namespace LMS.Blazor.Client.Services;
+
+public class StudentCourseClientService : IStudentCourseClientService
+{
+    private const string MyCourseEndpoint = "api/studentcourse/mycourse";
+    private const string ClassmatesEndpoint = "api/studentcourse/classmates";
+
+    private readonly IApiService _apiService;
+
+    public StudentCourseClientService(IApiService apiService)
+    {
+        _apiService = apiService;
+    }
+
+    public Task<CourseDto?> GetMyCourseAsync(CancellationToken ct = default) =>
+        _apiService.GetAllowNotFoundAsync<CourseDto>(MyCourseEndpoint, ct);
+
+    public async Task<IReadOnlyList<StudentDto>> GetClassmatesAsync(CancellationToken ct = default)
+    {
+        var list = await _apiService.GetAllowNotFoundAsync<List<StudentDto>>(ClassmatesEndpoint, ct);
+        return list ?? new List<StudentDto>();
+    }
+}

--- a/LMS.Blazor/LMS.Blazor/Services/ServerNoOpApiService.cs
+++ b/LMS.Blazor/LMS.Blazor/Services/ServerNoOpApiService.cs
@@ -12,6 +12,12 @@ public class ServerNoOpApiService(ILogger<ServerNoOpApiService> logger) : IApiSe
         return Task.FromResult<T?>(default);
     }
 
+    public Task<T?> GetAllowNotFoundAsync<T>(string endpoint, CancellationToken ct = default)
+    {
+        _logger.LogWarning("ServerNoOpApiService called for: {Endpoint}", endpoint);
+        return Task.FromResult<T?>(default);
+    }
+
     public Task<T?> PostAsync<T>(string endpoint, object body, CancellationToken ct = default)
     {
         _logger.LogWarning("ServerNoOpApiService called for: {Endpoint}", endpoint);

--- a/Lexicon LMS Project2.tsv
+++ b/Lexicon LMS Project2.tsv
@@ -1,0 +1,104 @@
+Title	URL	Assignees	Status	Linked pull requests	Sub-issues progress	Priority	Size	Estimate	Labels
+Date Validation & Constraints	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/78		Backlog			P1			back-end
+Responsive UI	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/71		Backlog			P0			
+Assignment Submissions	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/75		Backlog			P1			
+Feedback System	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/77		Backlog			P1			
+Notification System	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/80		Backlog			P1			
+Password Reset	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/83		Backlog			P2			
+GDPR & Account Deletion	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/84		Backlog			P2			
+Email Invitations	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/86		Backlog			P2			
+Mobile responsiveness polish	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/99		Backlog						
+Final demo preparation	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/97		Backlog						
+Testing & bug fixes	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/96		Backlog						
+Setup auth middleware	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/102		Backlog						
+Create User entity	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/103		Backlog						
+Create Enrollment Entity	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/119		Backlog						
+Create Feedback Entity	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/121		Backlog						
+Create Notification Entity	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/122		Backlog						
+Testing & Verification	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/128		Backlog						
+Create Blazor Components	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/132		Backlog						
+Design & Styling	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/133		Backlog						
+Create Blazor Components	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/134		Backlog						
+Design & Styling	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/135		Backlog						
+Testing & Validation	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/139		Backlog						
+Add Authentication & Authorization	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/141		Backlog						
+Integration with Navigation	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/142		Backlog						
+Testing & Validation	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/143		Backlog						
+Documentation & Code Quality	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/144		Backlog						
+Mobile Responsiveness	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/145		Backlog						
+Integration Testing	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/146		Backlog						
+Deployment & Final Checks	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/147		Backlog						
+Documentation & Code Review	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/148		Backlog						
+Final Testing & Sign-Off	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/149		Backlog						
+Verify API Endpoints Available	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/159		Backlog						
+Create Frontend User Service	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/160		Backlog						
+Create Blazor Components	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/161		Backlog						
+Design & Styling	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/162		Backlog						
+Mobile Responsiveness	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/163		Backlog						
+Testing & Validation	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/164		Backlog						
+Code Quality & Documentation	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/165		Backlog						
+Integration & Final Testing	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/166		Backlog						
+Add Document to Module	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/179		Backlog						
+Add Document to Activity	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/180		Backlog						
+Create Document	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/182		Backlog						
+Get Document (Id?)	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/183		Backlog						
+Get attached Documents	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/184		Backlog						
+Get attached Documents	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/185		Backlog						
+Get Activities	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/186		Backlog						
+Add Activity to Module	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/187		Backlog						
+Update Document (FileName, DisplayName, Description)	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/188		Backlog						
+Delete Document	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/189		Backlog						
+Create Submission	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/191		Backlog						
+Get Submission	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/192		Backlog						
+Delete Submission	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/193		Backlog						
+Update Submission details (StudentId?, ActivityId?, Body, SubmittedAt, IsLate, FeedbackText, FeedbackGivenAt)	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/194		Backlog						
+Add Module	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/199		Backlog						
+Get Modules	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/200		Backlog						
+Delete Module (from Course)	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/201		Backlog						
+Attach Document	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/202		Backlog						
+Delete Document (from Course)	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/203		Backlog						
+Delete Activity (from Module)	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/204		Backlog						
+Delete Document (from Module)	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/205		Backlog						
+Delete Document from Activity	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/206		Backlog						
+Add Student to Course	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/207		Backlog						
+Add Teacher to Course	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/208		Backlog						
+Add/Remove Submission?	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/209		Backlog						
+Database Setup & Entity Framework sprint2	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/213		Backlog		0 / 4 (0%)				
+Admin-roll	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/224		Backlog						
+Create Paged Dto baseclass	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/225		Sprintlog						back-end
+Module Schedule (Student)	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/66		Sprintlog			P0			back-end, front-end
+Document Management	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/73	kalleloko	Sprintlog			P1			back-end
+Module Schedule (Teacher)	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/226		Sprintlog						back-end, front-end
+Navigation & Routing	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/72	amjadnatouf	In progress			P0			front-end
+Course Schedule (Module View)	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/65	louai20	In progress			P0			back-end, front-end
+Submission Service DB Connection	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/190	kalleloko	In progress		0 / 5 (0%)				back-end
+Course Service DB Connection	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/195	kalleloko	In progress		3 / 10 (30%)				back-end
+REST API Foundation	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/70	louai20	In progress		4 / 9 (44%)	P0			back-end
+Student Course View	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/64	Polyakovleo	In progress		1 / 8 (12%)	P0			back-end, front-end
+User Management	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/68	Bullhoff	In progress		0 / 8 (0%)	P0			front-end
+Activity Service DB Connection	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/169	FelixHavlind	In progress		6 / 10 (60%)				back-end
+Create API Endpoints (Backend)	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/130	Polyakovleo	Done						
+Course Administration Interface	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/67	amjadnatouf	Done		8 / 8 (100%)	P0			
+Database Setup & Entity Framework	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/69	kalleloko	Done		14 / 14 (100%)	P0			
+Document Service DB Connection	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/181	FelixHavlind	Done		0 / 4 (0%)				
+Module Service DB Connection	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/174	kalleloko	Done		4 / 4 (100%)				
+Create Seed Data	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/127	kalleloko	Done						
+Setup Blazor project & dependencies	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/74		Done						
+Login page displays email and password fields	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/105		Done						
+Password is encrypted using a secure hashing algorithm (bcrypt/Argon2)	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/106		Done						
+Login validates credentials against database	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/107		Done						
+User Authentication & Registration	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/63	FelixHavlind	Done		7 / 7 (100%)	P0			
+Authentication token/session created on successful login	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/108		Done						
+Failed login attempts show error message	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/109		Done						
+Users cannot access protected pages without authentication	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/110		Done						
+Logout clears session/token	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/111		Done						
+Create Project Structure & Setup	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/112		Done			P0			
+Create Enum Classes	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/113		Done						
+Create User Entity	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/114		Done						
+Create Course Entity	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/115		Done						
+Create Module Entity	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/116		Done						
+Create Activity Entity	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/117		Done						
+Create Document Entity	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/118		Done						
+Create Submission Entity	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/120		Done						
+Configure Relationships in DbContext	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/123		Done						
+Create Database Indexes	https://github.com/Lexicon-LMS-Grupp4/LMS/issues/124		Done						


### PR DESCRIPTION
feat(blazor): Student Course View page and API client (#64)

Add end-to-end Student Course View for enrolled students.

Blazor (WASM):
- New page /student/course with course card, classmates table, loading/error/empty states
- IStudentCourseClientService + StudentCourseClientService calling LMS API via api/proxy
- Extend IApiService with GetAllowNotFoundAsync<T> for 404-safe GETs (ClientApiService + ServerNoOpApiService)
- Register student course client in LMS.Blazor.Client Program.cs
- NavMenu: "My course" link for Student role

API (already integrated):
- GET /api/studentcourse/mycourse and GET /api/studentcourse/classmates with JWT

Config:
- JwtSettings:SecretKey in appsettings.Development.json for local dev
- Early validation in ConfigureAuthentication if SecretKey is missing

To start API and Blazor CLient you need to setup Visual studio Properly

![newProfile](https://github.com/user-attachments/assets/3c725f2d-a4d7-4a66-96cc-006532da208f)
![API+BlazorStart](https://github.com/user-attachments/assets/f01926a4-2a9f-4522-a92b-f266b1075df7)


LogIn:
Student: student@test.com
Pass on my side : 123
You can check it yourself like this (in the LMS.API directory using PowerShell ): `dotnet user-secrets list --project LMS.API`

Closes #64
