### PR TITLE
Refactor document handling and add file upload support for submissions


### DIFF
--- a/Domain.Contracts/Storage/IDocumentManager.cs
+++ b/Domain.Contracts/Storage/IDocumentManager.cs
@@ -82,4 +82,8 @@ public interface IDocumentManager
     /// The submission whose attached document should be removed.
     /// </param>
     Task RemoveFromSubmissionAsync(Submission submission);
+
+    Task DeleteFileAsync(Document document);
+    Task DeleteManyAsync(IEnumerable<Document> documents);
+    Task<Stream> OpenReadAsync(Document document);
 }

--- a/Domain.Contracts/Storage/IDocumentManager.cs
+++ b/Domain.Contracts/Storage/IDocumentManager.cs
@@ -1,0 +1,85 @@
+﻿using Domain.Models.Entities;
+using Microsoft.AspNetCore.Http;
+
+namespace Domain.Contracts.Storage;
+
+/// <summary>
+/// Provides helper methods for creating, attaching files to, persisting,
+/// replacing, and removing <see cref="Document"/> entities.
+/// </summary>
+public interface IDocumentManager
+{
+    /// <summary>
+    /// Creates a new <see cref="Document"/> entity with the provided ownership
+    /// relation and optional description, but does not attach any file or save
+    /// the entity to the database.
+    /// </summary>
+    /// <param name="userId">
+    /// The id of the user who uploads and owns the document metadata as uploader.
+    /// </param>
+    /// <param name="courseId">
+    /// The id of the related course, if the document belongs to a course.
+    /// </param>
+    /// <param name="moduleId">
+    /// The id of the related module, if the document belongs to a module.
+    /// </param>
+    /// <param name="activityId">
+    /// The id of the related activity, if the document belongs to an activity.
+    /// </param>
+    /// <param name="submissionId">
+    /// The id of the related submission, if the document belongs to a submission.
+    /// </param>
+    /// <param name="description">
+    /// An optional description to store on the document.
+    /// </param>
+    /// <returns>
+    /// A new <see cref="Document"/> entity with uploader and ownership fields populated.
+    /// </returns>
+    Task<Document> CreateEntityAsync(
+        string userId,
+        int? courseId = null,
+        int? moduleId = null,
+        int? activityId = null,
+        int? submissionId = null,
+        string? description = null);
+
+    /// <summary>
+    /// Saves the provided file to storage and copies its file metadata to the
+    /// given <see cref="Document"/> entity, but does not save the document to the database.
+    /// </summary>
+    /// <param name="document">
+    /// The document entity to update with file metadata.
+    /// </param>
+    /// <param name="file">
+    /// The uploaded file to attach to the document.
+    /// </param>
+    Task AttachFileAsync(Document document, IFormFile file);
+
+    /// <summary>
+    /// Persists the provided <see cref="Document"/> entity to the database.
+    /// </summary>
+    /// <param name="document">
+    /// The document entity to save.
+    /// </param>
+    Task SaveDocumentAsync(Document document);
+
+    /// <summary>
+    /// Replaces the current document attached to the given submission with a new one
+    /// created from the provided file.
+    /// </summary>
+    /// <param name="submission">
+    /// The submission whose document should be replaced.
+    /// </param>
+    /// <param name="file">
+    /// The new file to attach to the submission.
+    /// </param>
+    Task ReplaceForSubmissionAsync(Submission submission, IFormFile file);
+
+    /// <summary>
+    /// Removes the document currently attached to the given submission.
+    /// </summary>
+    /// <param name="submission">
+    /// The submission whose attached document should be removed.
+    /// </param>
+    Task RemoveFromSubmissionAsync(Submission submission);
+}

--- a/LMS.API/Extensions/ServiceExtensions.cs
+++ b/LMS.API/Extensions/ServiceExtensions.cs
@@ -1,6 +1,8 @@
+using Domain.Contracts.Storage;
 using LMS.API.DependencyInjection;
 using LMS.Infractructure.Data;
 using LMS.Infractructure.Repositories;
+using LMS.Infrastructure.Storage;
 using LMS.Presentation;
 using LMS.Services;
 using LMS.Services.Access;
@@ -117,5 +119,7 @@ public static class ServiceExtensions
         services.AddScoped<ILmsRelationResolver, LmsRelationResolver>();
         services.AddScoped<IUserAccessContext, UserAccessContext>();
         services.AddScoped<IUserAccessContextFactory, UserAccessContextFactory>();
+
+        services.AddScoped<IDocumentManager, DocumentManager>();
     }
 }

--- a/LMS.Infractructure/Repositories/SubmissionRepository.cs
+++ b/LMS.Infractructure/Repositories/SubmissionRepository.cs
@@ -34,7 +34,8 @@ public class SubmissionRepository(ApplicationDbContext context) : RepositoryBase
                     (studentId == null || s.StudentId == studentId),
                 trackChanges)
             .Include(a => a.Activity).ThenInclude(a => a.Module).ThenInclude(m => m.Course)
-            .Include(a => a.Student);
+            .Include(a => a.Student)
+            .Include(a => a.Document);
     }
     public async Task<Submission?> GetSubmissionAsync(int id, bool trackChanges = false)
     {

--- a/LMS.Infractructure/Storage/DocumentManager.cs
+++ b/LMS.Infractructure/Storage/DocumentManager.cs
@@ -96,8 +96,30 @@ public class DocumentManager(
         unitOfWork.Documents.Delete(document);
         submission.Document = null;
 
-        await fileStorage.DeleteAsync(document.StoredFileName);
+        await DeleteFileAsync(document);
         await unitOfWork.CompleteAsync();
     }
 
+    public async Task DeleteFileAsync(Document document)
+    {
+        await fileStorage.DeleteAsync(document.StoredFileName);
+    }
+
+    public async Task DeleteManyAsync(IEnumerable<Document> documents)
+    {
+        ArgumentNullException.ThrowIfNull(documents);
+
+        foreach (var document in documents)
+        {
+            await DeleteFileAsync(document);
+            unitOfWork.Documents.Delete(document);
+        }
+
+        await unitOfWork.CompleteAsync();
+    }
+
+    public async Task<Stream> OpenReadAsync(Document document)
+    {
+        return await fileStorage.OpenReadAsync(document.StoredFileName);
+    }
 }

--- a/LMS.Infractructure/Storage/DocumentManager.cs
+++ b/LMS.Infractructure/Storage/DocumentManager.cs
@@ -1,0 +1,103 @@
+﻿using Domain.Contracts.Repositories;
+using Domain.Contracts.Storage;
+using Domain.Models.Entities;
+using Domain.Models.Exceptions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+
+namespace LMS.Infrastructure.Storage;
+
+public class DocumentManager(
+    IFileStorage fileStorage,
+    UserManager<ApplicationUser> userManager,
+    IUnitOfWork unitOfWork) : IDocumentManager
+{
+    public async Task<Document> CreateEntityAsync(
+        string userId,
+        int? courseId = null,
+        int? moduleId = null,
+        int? activityId = null,
+        int? submissionId = null,
+        string? description = null)
+    {
+        var user = await userManager.FindByIdAsync(userId)
+            ?? throw new UnauthorizedAccessException($"User by id {userId} does not exist");
+
+        return new Document
+        {
+            UploadedByUserId = userId,
+            CourseId = courseId,
+            ModuleId = moduleId,
+            ActivityId = activityId,
+            SubmissionId = submissionId,
+            Description = description ?? string.Empty
+        };
+    }
+
+    public async Task AttachFileAsync(Document document, IFormFile file)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        if (file == null)
+        {
+            throw new BadRequestException("File is missing.");
+        }
+
+        var savedFileResult = await fileStorage.SaveAsync(file);
+
+        document.StoredFileName = savedFileResult.FileName;
+        document.FileSize = savedFileResult.FileSize;
+        document.ContentType = file.ContentType;
+        document.DisplayName = file.FileName;
+        document.UploadedAt = DateTime.UtcNow;
+    }
+
+    public async Task SaveDocumentAsync(Document document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        unitOfWork.Documents.Create(document);
+        await unitOfWork.CompleteAsync();
+    }
+
+    public async Task ReplaceForSubmissionAsync(Submission submission, IFormFile file)
+    {
+        ArgumentNullException.ThrowIfNull(submission);
+
+        if (file == null)
+        {
+            throw new BadRequestException("File is missing.");
+        }
+
+        await RemoveFromSubmissionAsync(submission);
+
+        var document = await CreateEntityAsync(
+            submission.StudentId,
+            submissionId: submission.Id);
+
+        await AttachFileAsync(document, file);
+
+        submission.Document = document;
+
+        await unitOfWork.CompleteAsync();
+    }
+
+    public async Task RemoveFromSubmissionAsync(Submission submission)
+    {
+        ArgumentNullException.ThrowIfNull(submission);
+
+        if (submission.Document == null)
+        {
+            return;
+        }
+
+        var document = submission.Document;
+
+        unitOfWork.Documents.Delete(document);
+        submission.Document = null;
+
+        await fileStorage.DeleteAsync(document.StoredFileName);
+        await unitOfWork.CompleteAsync();
+    }
+
+}

--- a/LMS.Presentation/Controllers/SubmissionsController.cs
+++ b/LMS.Presentation/Controllers/SubmissionsController.cs
@@ -67,7 +67,7 @@ public class SubmissionsController : LmsControllerBase
     [SwaggerResponse(StatusCodes.Status201Created, "Submission created successfully")]
     [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid input")]
     [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden")]
-    public async Task<IActionResult> CreateSubmission([FromBody] CreateSubmissionDto dto)
+    public async Task<IActionResult> CreateSubmission([FromForm] CreateSubmissionDto dto)
     {
         var submission = await serviceManager.SubmissionService.CreateSubmissionAsync(UserId, dto);
         return CreatedAtAction(nameof(GetSubmissionById), new { id = submission.Id }, submission);
@@ -81,7 +81,7 @@ public class SubmissionsController : LmsControllerBase
     [SwaggerResponse(StatusCodes.Status200OK, "Submission updated successfully")]
     [SwaggerResponse(StatusCodes.Status404NotFound, "Submission not found")]
     [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden")]
-    public async Task<IActionResult> UpdateSubmission(int id, [FromBody] UpdateSubmissionDto dto)
+    public async Task<IActionResult> UpdateSubmission(int id, [FromForm] UpdateSubmissionDto dto)
     {
         await serviceManager.SubmissionService.UpdateSubmissionAsync(id, UserId, dto);
         return NoContent();
@@ -95,7 +95,7 @@ public class SubmissionsController : LmsControllerBase
     [SwaggerResponse(StatusCodes.Status200OK, "Submission updated successfully")]
     [SwaggerResponse(StatusCodes.Status404NotFound, "Submission not found")]
     [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden")]
-    public async Task<IActionResult> PatchSubmission(int id, [FromBody] PatchSubmissionDto dto)
+    public async Task<IActionResult> PatchSubmission(int id, [FromForm] PatchSubmissionDto dto)
     {
         await serviceManager.SubmissionService.UpdateSubmissionPartiallyAsync(id, UserId, dto);
         return NoContent();

--- a/LMS.Services/ActivityService.cs
+++ b/LMS.Services/ActivityService.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using Domain.Contracts.Repositories;
+using Domain.Contracts.Storage;
 using Domain.Models.Entities;
 using Domain.Models.Exceptions;
 using LMS.Infractructure.Extensions;
@@ -20,11 +21,13 @@ namespace LMS.Services
         IMapper mapper,
         ILmsAccessService lmsAccessService,
         IUserAccessContextFactory userAccessContextFactory,
+        IDocumentManager documentManager,
         UserManager<ApplicationUser> userManager) : IActivityService
     {
         private readonly UserManager<ApplicationUser> _userManager = userManager;
         private readonly IUnitOfWork _unitOfWork = unitOfWork;
         private readonly IMapper _mapper = mapper;
+        private readonly IDocumentManager _documentManager = documentManager;
         private readonly ILmsAccessService _lmsAccessService = lmsAccessService;
         private readonly IUserAccessContextFactory _userAccessContextFactory = userAccessContextFactory;
 
@@ -116,6 +119,11 @@ namespace LMS.Services
         public async Task DeleteActivityAsync(int id, string userId)
         {
             var activity = await GetTeacherAccessedActivity(id, userId);
+
+            if (activity.Documents.Any())
+            {
+                await documentManager.DeleteManyAsync(activity.Documents);
+            }
 
             _unitOfWork.Activities.Delete(activity);
             await _unitOfWork.CompleteAsync();

--- a/LMS.Services/CourseService.cs
+++ b/LMS.Services/CourseService.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using Domain.Contracts.Repositories;
+using Domain.Contracts.Storage;
 using Domain.Models.Entities;
 using Domain.Models.Exceptions;
 using LMS.Services.Access;
@@ -15,17 +16,19 @@ public class CourseService : ICourseService
     private readonly IMapper mapper;
     private readonly ILmsAccessService lmsAccessService;
     private readonly IUserAccessContextFactory userAccessContextFactory;
-
+    private readonly IDocumentManager documentManager;
     public CourseService(
         IUnitOfWork unitOfWork,
         IMapper mapper,
         ILmsAccessService lmsAccessService,
+        IDocumentManager documentManager,
         IUserAccessContextFactory userAccessContextFactory)
     {
         this.unitOfWork = unitOfWork;
         this.mapper = mapper;
         this.lmsAccessService = lmsAccessService;
         this.userAccessContextFactory = userAccessContextFactory;
+        this.documentManager = documentManager;
     }
 
     public async Task<PagedResultDto<CourseDto>> GetAllCoursesAsync(string userId, int page, int pageSize)
@@ -104,6 +107,11 @@ public class CourseService : ICourseService
             ?? throw new NotFoundException($"Course with id {id} was not found.");
 
         await lmsAccessService.EnsureTeacherForCourseAsync(userId, course);
+
+        if (course.Documents.Any())
+        {
+            await documentManager.DeleteManyAsync(course.Documents);
+        }
 
         unitOfWork.Courses.Delete(course);
         await unitOfWork.CompleteAsync();

--- a/LMS.Services/DocumentService.cs
+++ b/LMS.Services/DocumentService.cs
@@ -19,6 +19,7 @@ public class DocumentService(
     IUnitOfWork unitOfWork,
     IMapper mapper,
     IFileStorage fileStorage,
+    IDocumentManager documentManager,
     ILmsRelationResolver lmsRelationResolver,
     ILmsAccessService lmsAccessService,
     IUserAccessContextFactory userAccessContextFactory,
@@ -31,6 +32,7 @@ public class DocumentService(
     private readonly ILmsRelationResolver _lmsRelationResolver = lmsRelationResolver;
     private readonly ILmsAccessService _lmsAccessService = lmsAccessService;
     private readonly IUserAccessContextFactory _userAccessContextFactory = userAccessContextFactory;
+    private readonly IDocumentManager _documentManager = documentManager;
 
     /// <summary>
     /// Retrieves a paged list of documents accessible to the specified user.
@@ -137,24 +139,20 @@ public class DocumentService(
             throw new BadRequestException("File is missing.");
         }
 
-        var user = await _userManager.FindByIdAsync(userId) ??
-            throw new UnauthorizedAccessException($"User by id {userId} does not exist");
-
         await ValidateCreateAccessAsync(userId, dto);
 
-        var savedFileResult = await _fileStorage.SaveAsync(dto.File);
+        var document = await _documentManager.CreateEntityAsync(
+            userId,
+            courseId: dto.CourseId,
+            moduleId: dto.ModuleId,
+            activityId: dto.ActivityId,
+            submissionId: dto.SubmissionId,
+            description: dto.Description);
 
-        var document = _mapper.Map<Document>(dto);
+        await _documentManager.AttachFileAsync(document, dto.File);
+        await _documentManager.SaveDocumentAsync(document);
 
-        document.UploadedByUser = user;
-        document.UploadedAt = DateTime.UtcNow;
-        document.FileSize = savedFileResult.FileSize;
-        document.StoredFileName = savedFileResult.FileName;
-
-        _unitOfWork.Documents.Create(document);
-        await _unitOfWork.CompleteAsync();
-
-        var createdDocument = await _unitOfWork.Documents.GetDocumentWithAccessRelationsAsync(document.Id)
+        var createdDocument = await _unitOfWork.Documents.GetDocumentAsync(document.Id)
             ?? throw new NotFoundException($"Document with id {document.Id} does not exist after creation.");
 
         return _mapper.Map<DocumentDto>(createdDocument);

--- a/LMS.Services/DocumentService.cs
+++ b/LMS.Services/DocumentService.cs
@@ -7,7 +7,6 @@ using LMS.Infractructure.Extensions;
 using LMS.Services.Access;
 using LMS.Shared.DTOs.Common;
 using LMS.Shared.DTOs.Document;
-using Microsoft.AspNetCore.Identity;
 using Service.Contracts;
 
 namespace LMS.Services;
@@ -18,17 +17,13 @@ namespace LMS.Services;
 public class DocumentService(
     IUnitOfWork unitOfWork,
     IMapper mapper,
-    IFileStorage fileStorage,
     IDocumentManager documentManager,
     ILmsRelationResolver lmsRelationResolver,
     ILmsAccessService lmsAccessService,
-    IUserAccessContextFactory userAccessContextFactory,
-    UserManager<ApplicationUser> userManager) : IDocumentService
+    IUserAccessContextFactory userAccessContextFactory) : IDocumentService
 {
-    private readonly UserManager<ApplicationUser> _userManager = userManager;
     private readonly IUnitOfWork _unitOfWork = unitOfWork;
     private readonly IMapper _mapper = mapper;
-    private readonly IFileStorage _fileStorage = fileStorage;
     private readonly ILmsRelationResolver _lmsRelationResolver = lmsRelationResolver;
     private readonly ILmsAccessService _lmsAccessService = lmsAccessService;
     private readonly IUserAccessContextFactory _userAccessContextFactory = userAccessContextFactory;
@@ -109,7 +104,7 @@ public class DocumentService(
             throw new NotFoundException("File not found.");
         }
 
-        var stream = await _fileStorage.OpenReadAsync(document.StoredFileName);
+        var stream = await _documentManager.OpenReadAsync(document);
 
         var contentType = string.IsNullOrWhiteSpace(document.ContentType)
             ? "application/octet-stream"
@@ -232,15 +227,7 @@ public class DocumentService(
         // TODO: option to soft delete instead of hard delete, add IsDeleted property to Document entity and filter it out in queries
 
         // remove the file from storage if it exists
-        if (!string.IsNullOrWhiteSpace(document.StoredFileName))
-        {
-            var success = await _fileStorage.DeleteAsync(document.StoredFileName);
-            if (!success)
-            {
-                // log the failure to delete the file, but do not prevent the document record from being deleted
-                // consider implementing a retry mechanism or marking the document for cleanup if file deletion fails
-            }
-        }
+        await _documentManager.DeleteFileAsync(document);
 
         _unitOfWork.Documents.Delete(document);
         await _unitOfWork.CompleteAsync();

--- a/LMS.Services/ModuleService.cs
+++ b/LMS.Services/ModuleService.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using Domain.Contracts.Repositories;
+using Domain.Contracts.Storage;
 using Domain.Models.Entities;
 using Domain.Models.Exceptions;
 using LMS.Infractructure.Extensions;
@@ -19,15 +20,18 @@ public class ModuleService : IModuleService
     private readonly IMapper mapper;
     private readonly ILmsAccessService lmsAccessService;
     private readonly IUserAccessContextFactory userAccessContextFactory;
+    private readonly IDocumentManager documentManager;
     public ModuleService(IUnitOfWork unitOfWork,
                          IMapper mapper,
                          ILmsAccessService lmsAccessService,
+                         IDocumentManager documentManager,
                          IUserAccessContextFactory userAccessContextFactor)
     {
         this.unitOfWork = unitOfWork;
         this.mapper = mapper;
         this.lmsAccessService = lmsAccessService;
         this.userAccessContextFactory = userAccessContextFactor;
+        this.documentManager = documentManager;
     }
     public async Task<PagedResultDto<ModuleDto>> GetAllModulesAsync(string userId, int page, int pageSize, int? courseId = null)
     {
@@ -177,9 +181,15 @@ public class ModuleService : IModuleService
 
     public async Task DeleteModuleAsync(int id, string userId)
     {
-        var module = await unitOfWork.Modules.FindByIdOrThrowAsync(id, trackChanges: true);
+        var module = await unitOfWork.Modules.GetModuleAsync(id, trackChanges: true)
+            ?? throw new NotFoundException($"Module with id {id} does not exist.");
 
         await lmsAccessService.EnsureTeacherForCourseAsync(userId, module.CourseId);
+
+        if (module.Documents.Any())
+        {
+            await documentManager.DeleteManyAsync(module.Documents);
+        }
 
         unitOfWork.Modules.Delete(module);
         await unitOfWork.CompleteAsync();

--- a/LMS.Services/SubmissionService.cs
+++ b/LMS.Services/SubmissionService.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using Domain.Contracts.Repositories;
+using Domain.Contracts.Storage;
 using Domain.Models.Entities;
 using Domain.Models.Exceptions;
 using LMS.Infractructure.Extensions;
@@ -7,6 +8,7 @@ using LMS.Services.Access;
 using LMS.Shared.DTOs.Common;
 using LMS.Shared.DTOs.Submission;
 using LMS.Shared.Request;
+using Microsoft.AspNetCore.Http;
 using Service.Contracts;
 
 namespace LMS.Services;
@@ -18,17 +20,20 @@ public class SubmissionService : ISubmissionService
 {
     private readonly IUnitOfWork unitOfWork;
     private readonly IMapper mapper;
+    private readonly IDocumentManager documentManager;
     private readonly ILmsAccessService lmsAccessService;
     private readonly IUserAccessContextFactory userAccessContextFactory;
     public SubmissionService(IUnitOfWork unitOfWork,
                              IMapper mapper,
                              ILmsAccessService lmsAccessService,
-                             IUserAccessContextFactory userAccessContextFactor)
+                             IUserAccessContextFactory userAccessContextFactor,
+                             IDocumentManager documentManager)
     {
         this.unitOfWork = unitOfWork;
         this.mapper = mapper;
         this.lmsAccessService = lmsAccessService;
         this.userAccessContextFactory = userAccessContextFactor;
+        this.documentManager = documentManager;
     }
     public async Task<PagedResultDto<SubmissionDto>> GetAllSubmissionsAsync(string userId, SubmissionsRequestParams queryDto)
     {
@@ -87,6 +92,7 @@ public class SubmissionService : ISubmissionService
 
         await lmsAccessService.EnsureCanAccessActivityAsync(userId, activity);
 
+
         var submission = mapper.Map<Submission>(dto);
         submission.StudentId = userId;
         submission.SubmittedAt = DateTime.UtcNow;
@@ -96,8 +102,21 @@ public class SubmissionService : ISubmissionService
         await unitOfWork.CompleteAsync();
 
         // refetch new submission with navprops to verify it exists
-        var createdSubmission = await unitOfWork.Submissions.GetSubmissionAsync(submission.Id)
+        var createdSubmission = await unitOfWork.Submissions.GetSubmissionAsync(submission.Id, trackChanges: true)
             ?? throw new InvalidOperationException($"Submission with id {submission.Id} could not be loaded after creation.");
+
+        if (dto.File != null)
+        {
+            var document = await documentManager.CreateEntityAsync(
+                userId,
+                submissionId: createdSubmission.Id);
+
+            await documentManager.AttachFileAsync(document, dto.File);
+            await documentManager.SaveDocumentAsync(document);
+
+            createdSubmission.Document = document;
+            await unitOfWork.CompleteAsync();
+        }
 
         return mapper.Map<SubmissionDto>(createdSubmission);
     }
@@ -106,7 +125,7 @@ public class SubmissionService : ISubmissionService
         ArgumentNullException.ThrowIfNull(dto);
         var submission = await GetStudentAccessedSubmission(id, userId);
 
-        await InternallyUpdateSubmissionAsync(submission, dto.Body, dto.ActivityId, dto.DocumentId);
+        await InternallyUpdateSubmissionAsync(submission, dto.Body, dto.ActivityId, dto.File);
     }
 
     public async Task UpdateSubmissionPartiallyAsync(int id, string userId, PatchSubmissionDto dto)
@@ -118,22 +137,26 @@ public class SubmissionService : ISubmissionService
         await InternallyUpdateSubmissionAsync(submission,
                                               dto.Body ?? submission.Body ?? string.Empty,
                                               dto.ActivityId ?? submission.Activity.Id,
-                                              dto.DocumentId);
+                                              dto.File);
     }
-    private async Task InternallyUpdateSubmissionAsync(Submission submission, string body, int activityId, int? documentId)
+    private async Task InternallyUpdateSubmissionAsync(Submission submission, string body, int activityId, IFormFile? file)
     {
         submission.Body = body;
-        if (documentId != null)
-        {
-            submission.Document = await unitOfWork.Documents.FindByIdOrThrowAsync(documentId.Value, trackChanges: true);
-        }
         submission.ActivityId = activityId;
+        if (file != null)
+        {
+            await documentManager.ReplaceForSubmissionAsync(submission, file);
+            return;
+        }
 
         await unitOfWork.CompleteAsync();
     }
     public async Task DeleteSubmissionAsync(int id, string userId)
     {
         var submission = await GetStudentAccessedSubmission(id, userId);
+
+        await documentManager.RemoveFromSubmissionAsync(submission);
+
         unitOfWork.Submissions.Delete(submission);
         await unitOfWork.CompleteAsync();
     }

--- a/LMS.Services/SubmissionService.cs
+++ b/LMS.Services/SubmissionService.cs
@@ -109,7 +109,8 @@ public class SubmissionService : ISubmissionService
         {
             var document = await documentManager.CreateEntityAsync(
                 userId,
-                submissionId: createdSubmission.Id);
+                submissionId: createdSubmission.Id,
+                description: dto.FileDescription);
 
             await documentManager.AttachFileAsync(document, dto.File);
             await documentManager.SaveDocumentAsync(document);

--- a/LMS.Shared/DTOs/Submission/CreateSubmissionDto.cs
+++ b/LMS.Shared/DTOs/Submission/CreateSubmissionDto.cs
@@ -1,4 +1,6 @@
-﻿namespace LMS.Shared.DTOs.Submission;
+﻿using Microsoft.AspNetCore.Http;
+
+namespace LMS.Shared.DTOs.Submission;
 
 /// <summary>
 /// Data transfer object for creating a new submission.
@@ -9,5 +11,5 @@ public record CreateSubmissionDto
 {
     public required int ActivityId { get; init; }
     public string? Body { get; init; }
-    public int? DocumentId { get; init; }
+    public IFormFile? File { get; init; } = null!;
 }

--- a/LMS.Shared/DTOs/Submission/CreateSubmissionDto.cs
+++ b/LMS.Shared/DTOs/Submission/CreateSubmissionDto.cs
@@ -12,4 +12,5 @@ public record CreateSubmissionDto
     public required int ActivityId { get; init; }
     public string? Body { get; init; }
     public IFormFile? File { get; init; } = null!;
+    public string? FileDescription { get; init; }
 }

--- a/LMS.Shared/DTOs/Submission/PatchSubmissionDto.cs
+++ b/LMS.Shared/DTOs/Submission/PatchSubmissionDto.cs
@@ -1,4 +1,6 @@
-﻿namespace LMS.Shared.DTOs.Submission;
+﻿using Microsoft.AspNetCore.Http;
+
+namespace LMS.Shared.DTOs.Submission;
 
 /// <summary>
 /// Data transfer object for partially updating an existing submission.
@@ -9,5 +11,5 @@ public record PatchSubmissionDto
 {
     public int? ActivityId { get; init; }
     public string? Body { get; init; }
-    public int? DocumentId { get; init; }
+    public IFormFile File { get; init; } = null!;
 }

--- a/LMS.Shared/DTOs/Submission/UpdateSubmissionDto.cs
+++ b/LMS.Shared/DTOs/Submission/UpdateSubmissionDto.cs
@@ -1,4 +1,6 @@
-﻿namespace LMS.Shared.DTOs.Submission;
+﻿using Microsoft.AspNetCore.Http;
+
+namespace LMS.Shared.DTOs.Submission;
 
 /// <summary>
 /// Data transfer object for updating an existing submission.
@@ -9,5 +11,5 @@ public record UpdateSubmissionDto
 {
     public int ActivityId { get; init; }
     public string Body { get; init; } = string.Empty;
-    public int? DocumentId { get; init; }
+    public IFormFile File { get; init; } = null!;
 }


### PR DESCRIPTION
This is built upon [PR 274](https://github.com/Lexicon-LMS-Grupp4/LMS/pull/274). **Review this after that PR is merged!**

Introduces a new `IDocumentManager` to centralize document/file lifecycle logic, reducing responsibility in services and reusing storage-related operations across the application.

Also adds file upload support directly on submission create/update/patch flows by switching submission DTOs and controller endpoints to `multipart/form-data`, and ensures related documents are cleaned up when deleting courses, modules, activities, or submissions.