### PR TITLE
Add submission file upload/edit support in Blazor client


### DIFF
--- a/Domain.Contracts/Storage/IDocumentManager.cs
+++ b/Domain.Contracts/Storage/IDocumentManager.cs
@@ -73,7 +73,7 @@ public interface IDocumentManager
     /// <param name="file">
     /// The new file to attach to the submission.
     /// </param>
-    Task ReplaceForSubmissionAsync(Submission submission, IFormFile file);
+    Task ReplaceForSubmissionAsync(Submission submission, IFormFile file, string? fileDescription);
 
     /// <summary>
     /// Removes the document currently attached to the given submission.

--- a/LMS.Blazor/LMS.Blazor.Client/Components/DocumentWithDownload.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/DocumentWithDownload.razor
@@ -1,0 +1,62 @@
+﻿@using LMS.Shared.DTOs.Document
+@inject IDocumentService DocumentService
+
+@if (Document is not null)
+{
+    <div class="d-flex align-items-start gap-2 border rounded p-2 bg-light">
+        <i class="bi bi-file-earmark-text fs-4 text-muted"></i>
+
+        <div class="flex-grow-1">
+            <div class="fw-semibold small">
+                <a href="@GetFileUrl()" target="_blank" class="text-decoration-none">
+                    @Document.DisplayName
+                </a>
+            </div>
+
+            @if (ShowDescription && !string.IsNullOrWhiteSpace(Document.Description))
+            {
+                <div class="text-muted small">
+                    @Document.Description
+                </div>
+            }
+
+            @if (ShowUploadedBy && !string.IsNullOrWhiteSpace(Document.UploadedByUserName))
+            {
+                <div class="text-muted small">
+                    Uploaded by: @Document.UploadedByUserName
+                </div>
+            }
+
+            @if (ShowUploadedDate)
+            {
+                <div class="text-muted small">
+                    Uploaded at: @Document.UploadedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm")
+                </div>
+            }
+        </div>
+
+        
+        <a href="@GetFileUrl(true)"
+                class="btn btn-sm btn-outline-primary"
+                target="_blank">
+            Download
+        </a>
+        
+    </div>
+}
+@code {
+    [Parameter] public DocumentDto? Document { get; set; }
+
+    [Parameter] public bool ShowUploadedBy { get; set; } = true;
+    [Parameter] public bool ShowUploadedDate { get; set; } = true;
+    [Parameter] public bool ShowDescription { get; set; } = true;
+
+    private string GetFileUrl(bool download = false)
+    {
+        if (Document is null)
+            return "#";
+
+        return DocumentService.GetDocumentFileUrl(Document.Id, download);
+    }
+
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/UploadDocumentField.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/UploadDocumentField.razor
@@ -1,0 +1,130 @@
+﻿
+@using LMS.Blazor.Client.Uploads
+
+<div class="mb-3">
+    @if (!string.IsNullOrWhiteSpace(Label))
+    {
+        <label class="form-label fw-semibold">@Label</label>
+    }
+
+    <BbFileUpload Files="files"
+                  FilesChanged="OnFilesChanged"
+                  MaxFileCount="1"
+                  ShowPreview="false"
+                  Accept="@Accept"
+                  Disabled="@Disabled" />
+
+    @if (!string.IsNullOrWhiteSpace(FileHelpText))
+    {
+        <div class="form-text">@FileHelpText</div>
+    }
+
+    @if (Value?.HasExistingDocument == true && Value.HasFile == false && !Value.RemoveExistingDocument)
+    {
+        <div class="text-muted small mt-2">
+            Current file: @Value.ExistingFileName
+        </div>
+    }
+
+    @if (Value?.HasFile == true && ShowFileName)
+    {
+        <div class="text-muted small mt-2">
+            Selected file: @Value.File?.Name
+        </div>
+    }
+
+    @if (AllowRemoveExistingDocument && Value?.HasExistingDocument == true && !Value.HasFile)
+    {
+        <div class="form-check mt-2">
+            <InputCheckbox class="form-check-input"
+                           Value="CurrentRemoveExistingDocument"
+                           ValueChanged="OnRemoveExistingDocumentChanged"
+                           ValueExpression="() => CurrentRemoveExistingDocument"
+                           disabled="@Disabled" />
+            <label class="form-check-label">
+                Remove current file
+            </label>
+        </div>
+    }
+</div>
+
+<div class="mb-3">
+    <label class="form-label">@DescriptionLabel</label>
+    <InputText class="form-control"
+               Value="CurrentDescription"
+               ValueChanged="OnDescriptionChanged"
+               ValueExpression="() => CurrentDescription"
+               placeholder="@DescriptionPlaceholder"
+               disabled="@Disabled" />
+</div>
+
+@code {
+    private IReadOnlyList<FileUploadItem>? files;
+
+    [Parameter]
+    public UploadDocumentValue? Value { get; set; }
+
+    [Parameter]
+    public EventCallback<UploadDocumentValue?> ValueChanged { get; set; }
+
+    [Parameter] public string? Label { get; set; } = "File";
+    [Parameter] public string DescriptionLabel { get; set; } = "Description";
+    [Parameter] public string DescriptionPlaceholder { get; set; } = "Describe the file";
+    [Parameter] public string? FileHelpText { get; set; } = "You can upload one file.";
+    [Parameter] public string Accept { get; set; } = ".pdf,.doc,.docx,.png,.jpg,.jpeg";
+    [Parameter] public bool Disabled { get; set; }
+    [Parameter] public bool ShowFileName { get; set; } = true;
+    [Parameter] public bool AllowRemoveExistingDocument { get; set; } = true;
+
+    private string CurrentDescription => Value?.Description ?? string.Empty;
+    private bool CurrentRemoveExistingDocument => Value?.RemoveExistingDocument ?? false;
+
+    protected override void OnParametersSet()
+    {
+        if (Value?.File is not null)
+        {
+            files = new List<FileUploadItem> { Value.File };
+        }
+        else
+        {
+            files = null;
+        }
+    }
+
+    private async Task OnFilesChanged(IReadOnlyList<FileUploadItem>? newFiles)
+    {
+        files = newFiles;
+
+        var current = Value ?? new UploadDocumentValue();
+        current.File = newFiles?.FirstOrDefault();
+
+        if (current.File is not null)
+        {
+            current.RemoveExistingDocument = false;
+        }
+
+        await ValueChanged.InvokeAsync(current);
+    }
+
+    private async Task OnDescriptionChanged(string newValue)
+    {
+        var current = Value ?? new UploadDocumentValue();
+        current.Description = newValue;
+
+        await ValueChanged.InvokeAsync(current);
+    }
+
+    private async Task OnRemoveExistingDocumentChanged(bool remove)
+    {
+        var current = Value ?? new UploadDocumentValue();
+        current.RemoveExistingDocument = remove;
+
+        if (remove)
+        {
+            current.File = null;
+            files = null;
+        }
+
+        await ValueChanged.InvokeAsync(current);
+    }
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/UploadDocumentField.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/UploadDocumentField.razor
@@ -51,7 +51,7 @@
 <div class="mb-3">
     <label class="form-label">@DescriptionLabel</label>
     <InputText class="form-control"
-               Value="CurrentDescription"
+               Value="@CurrentDescription"
                ValueChanged="OnDescriptionChanged"
                ValueExpression="() => CurrentDescription"
                placeholder="@DescriptionPlaceholder"

--- a/LMS.Blazor/LMS.Blazor.Client/LMS.Blazor.Client.csproj
+++ b/LMS.Blazor/LMS.Blazor.Client/LMS.Blazor.Client.csproj
@@ -19,4 +19,8 @@
     <ProjectReference Include="..\..\LMS.Shared\LMS.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Extensions\" />
+  </ItemGroup>
+
 </Project>

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/Student/StudentActivitySubmit.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/Student/StudentActivitySubmit.razor
@@ -187,12 +187,7 @@
                     @if (existingSubmission.Document is not null)
                     {
                         <p class="small fw-semibold text-muted mb-1">Attached file</p>
-                        <div class="d-flex align-items-center gap-2 border rounded p-2 bg-light">
-                            <i class="bi bi-file-earmark-text fs-4 text-muted"></i>
-                            <div>
-                                <div class="fw-semibold small">@existingSubmission.Document!.DisplayName</div>
-                            </div>
-                        </div>
+                        <DocumentWithDownload Document="@existingSubmission.Document"/>
                     }
 
                     @* ---- Feedback block ---- *@
@@ -273,7 +268,7 @@
                         
                     <div class="mb-3">
                         <UploadDocumentField
-                                Value="documentUpload"
+                                @bind-Value="documentUpload"
                                 Label="Attach File"
                                 DescriptionLabel="File description"
                                 DescriptionPlaceholder="Optional description" />

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/Student/StudentActivitySubmit.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/Student/StudentActivitySubmit.razor
@@ -1,10 +1,13 @@
 ﻿@page "/student/activities/{ActivityId:int}/submit"
 @attribute [Authorize(Roles = "Student")]
+@using LMS.Blazor.Client.Components
+@using LMS.Blazor.Client.Uploads
 @using LMS.Shared.DTOs.Activity
 @using LMS.Shared.DTOs.Document
 @using LMS.Shared.DTOs.Submission
 @using Domain.Models.Enums
 @inject IActivityService ActivityService
+@inject ISubmissionService SubmissionService
 @inject NavigationManager Navigation
 
 <PageTitle>Submit Activity</PageTitle>
@@ -152,12 +155,12 @@
         @* ==============================
            EXISTING SUBMISSION (if any)
            ============================== *@
-        @if (existingSubmission is not null)
+        @if (existingSubmission is not null && !showResubmitForm)
         {
             <div class="card mb-4 border-success">
                 <div class="card-header bg-success bg-opacity-10 d-flex flex-wrap justify-content-between align-items-center gap-2">
                     <h6 class="mb-0 text-success">
-                        <i class="bi bi-check-circle me-2"></i>Already Submitted
+                        <i class="bi bi-check-circle me-2"></i>Your submission
                     </h6>
                     <div class="d-flex gap-2 flex-wrap">
                         @if (existingSubmission.IsLate)
@@ -176,18 +179,18 @@
                 <div class="card-body">
                     @if (!string.IsNullOrEmpty(existingSubmission.Body))
                     {
-                        <p class="small fw-semibold text-muted mb-1">Your answer</p>
+                        <p class="small fw-semibold text-muted mb-1">Answer</p>
                         <div class="border rounded p-3 bg-light small" style="white-space:pre-wrap;">
                             @existingSubmission.Body
                         </div>
                     }
-                    else if (existingSubmission.Document is not null)
+                    @if (existingSubmission.Document is not null)
                     {
                         <p class="small fw-semibold text-muted mb-1">Attached file</p>
                         <div class="d-flex align-items-center gap-2 border rounded p-2 bg-light">
                             <i class="bi bi-file-earmark-text fs-4 text-muted"></i>
                             <div>
-                                <div class="fw-semibold small">@existingSubmission.Document.DisplayName</div>
+                                <div class="fw-semibold small">@existingSubmission.Document!.DisplayName</div>
                             </div>
                         </div>
                     }
@@ -219,7 +222,7 @@
                     {
                         <div class="mt-3">
                             <button class="btn btn-sm btn-outline-primary"
-                                    @onclick="() => showResubmitForm = !showResubmitForm">
+                                    @onclick="ToggleEditSubmission">
                                 <i class="bi bi-pencil me-1"></i>
                                 @(showResubmitForm ? "Cancel Edit" : "Edit Submission")
                             </button>
@@ -235,8 +238,8 @@
         @if (existingSubmission is null || showResubmitForm)
         {
             <div class="card mb-4 @(isOverdue ? "border-danger border-opacity-25" : "")">
-                <div class="card-header d-flex justify-content-between align-items-center">
-                    <h6 class="mb-0">
+                <div class="card-header d-flex bg-success bg-opacity-10 justify-content-between align-items-center">
+                    <h6 class="mb-0 text-success">
                         <i class="bi bi-send me-2"></i>
                         @(existingSubmission is null ? "Your Submission" : "Edit Submission")
                     </h6>
@@ -246,105 +249,73 @@
                     }
                 </div>
                 <div class="card-body">
-
-                    @* ---- Tab switcher: text vs file ---- *@
-                    <ul class="nav nav-tabs mb-3">
-                        <li class="nav-item">
-                            <button class="nav-link @(submissionTab == SubmissionTab.Text ? "active" : "")"
-                                    @onclick="() => submissionTab = SubmissionTab.Text">
-                                <i class="bi bi-textarea-t me-1"></i>Text Answer
-                            </button>
-                        </li>
-                        <li class="nav-item">
-                            <button class="nav-link @(submissionTab == SubmissionTab.File ? "active" : "")"
-                                    @onclick="() => submissionTab = SubmissionTab.File">
-                                <i class="bi bi-file-earmark-arrow-up me-1"></i>File Upload
-                            </button>
-                        </li>
-                    </ul>
-
-                    @if (submissionTab == SubmissionTab.Text)
-                    {
-                        <div class="mb-3">
-                            <label class="form-label fw-semibold">
-                                Your Answer
-                                @if (!isOverdue)
-                                {
-                                    <span class="text-danger">*</span>
-                                }
-                            </label>
-                            <textarea class="form-control @(formErrors.ContainsKey("Body") ? "is-invalid" : "")"
-                                      rows="8"
-                                      placeholder="Write your answer here..."
-                                      @bind="submissionBody"
-                                          disabled="@isOverdue">
-                            </textarea>
-                                @if (formErrors.TryGetValue("Body", out var bodyErr))
-                                {
-                                    <div class="invalid-feedback">@bodyErr</div>
-                                }
-                                <div class="form-text">
-                                    @submissionBody.Length characters
-                                </div>
-                            </div>
-                        }
-                    else
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">
+                            Your Answer
+                            @if (!isOverdue)
+                            {
+                                <span class="text-danger">*</span>
+                            }
+                        </label>
+                        <textarea class="form-control @(formErrors.ContainsKey("Body") ? "is-invalid" : "")"
+                                    rows="8"
+                                    placeholder="Write your answer here..."
+                                    @bind="submissionBody">
+                        </textarea>
+                        @if (formErrors.TryGetValue("Body", out var bodyErr))
                         {
-                            <div class="mb-3">
-                                <label class="form-label fw-semibold">Attach File</label>
-                                <div class="border rounded p-4 text-center bg-light @(formErrors.ContainsKey("File") ? "border-danger" : "")">
-                                    <i class="bi bi-cloud-upload fs-2 text-muted d-block mb-2"></i>
-                                    <p class="text-muted small mb-2">
-                                        File upload requires document storage backend — not yet available.
-                                    </p>
-                                    <input type="file"
-                                           class="form-control form-control-sm"
-                                           disabled
-                                           @onchange="HandleFilePicked" />
-                                </div>
-                                @if (formErrors.TryGetValue("File", out var fileErr))
-                                {
-                                    <div class="text-danger small mt-1">@fileErr</div>
-                                }
-                            </div>
+                            <div class="invalid-feedback">@bodyErr</div>
                         }
-
-                        @* ---- Submit button ---- *@
-                        <div class="d-flex gap-2 flex-wrap align-items-center">
-                            <button class="btn @(isOverdue ? "btn-warning" : "btn-primary")"
-                                    @onclick="SubmitAsync"
-                                    disabled="@(isSubmitting || isOverdue)">
-                                @if (isSubmitting)
-                                {
-                                    <span class="spinner-border spinner-border-sm me-1"></span>
-                                }
-                                else
-                                {
-                                    <i class="bi bi-send me-1"></i>
-                                }
-                                @(existingSubmission is null ? "Submit" : "Update Submission")
-                            </button>
-
-                            @if (existingSubmission is not null)
-                            {
-                                <button class="btn btn-outline-secondary"
-                                        @onclick="() => showResubmitForm = false">
-                                    Cancel
-                                </button>
-                            }
-
-                            @if (isOverdue)
-                            {
-                                <span class="text-danger small">
-                                    <i class="bi bi-lock me-1"></i>Submission closed — deadline has passed.
-                                </span>
-                            }
+                        <div class="form-text">
+                            @submissionBody.Length characters
                         </div>
                     </div>
+                        
+                    <div class="mb-3">
+                        <UploadDocumentField
+                                Value="documentUpload"
+                                Label="Attach File"
+                                DescriptionLabel="File description"
+                                DescriptionPlaceholder="Optional description" />
+                    </div>
+                        
+
+                    @* ---- Submit button ---- *@
+                    <div class="d-flex gap-2 flex-wrap align-items-center">
+                        <button class="btn @(isOverdue ? "btn-warning" : "btn-primary")"
+                                @onclick="SubmitAsync"
+                                disabled="@(isSubmitting || isOverdue)">
+                            @if (isSubmitting)
+                            {
+                                <span class="spinner-border spinner-border-sm me-1"></span>
+                            }
+                            else
+                            {
+                                <i class="bi bi-send me-1"></i>
+                            }
+                            @(existingSubmission is null ? "Submit" : "Update Submission")
+                        </button>
+
+                        @if (existingSubmission is not null)
+                        {
+                            <button class="btn btn-outline-secondary"
+                                    @onclick="() => showResubmitForm = false">
+                                Cancel
+                            </button>
+                        }
+
+                        @if (isOverdue)
+                        {
+                            <span class="text-danger small">
+                                <i class="bi bi-lock me-1"></i>Submission closed — deadline has passed.
+                            </span>
+                        }
+                    </div>
                 </div>
-            }
+            </div>
         }
-    </div>
+    }
+</div>
 
 @code {
     [Parameter] public int ActivityId { get; set; }
@@ -368,27 +339,49 @@
 
     // ---- Form state ----
     private string submissionBody = string.Empty;
-    private SubmissionTab submissionTab = SubmissionTab.Text;
+    private UploadDocumentValue documentUpload = new();
+
     private bool isSubmitting;
     private bool showResubmitForm;
     private Dictionary<string, string> formErrors = new();
 
     // ---- Lifecycle ----
-    protected override async Task OnInitializedAsync()
-        => await LoadActivityAsync();
+    private int? loadedActivityId;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (loadedActivityId != ActivityId)
+        {
+            loadedActivityId = ActivityId;
+            await LoadActivityAsync();
+        }
+    }
 
     private async Task LoadActivityAsync()
     {
         isLoading = true;
         loadError = null;
+        successMessage = null;
+        errorMessage = null;
+
         StateHasChanged();
 
         try
         {
             activity = await ActivityService.GetActivityByIdAsync(ActivityId);
 
+            existingSubmission = null;
+            submissionBody = string.Empty;
+            documentUpload = new UploadDocumentValue();
+            showResubmitForm = false;
+
             // TODO: once ISubmissionService is added to client, load existing submission:
-            // existingSubmission = await SubmissionService.GetMySubmissionForActivityAsync(ActivityId);
+            var pagedSubmissions = await SubmissionService.GetAllSubmissionsAsync(activityId: ActivityId);
+            if (pagedSubmissions?.TotalCount > 0)
+            {
+                existingSubmission = pagedSubmissions.Items[0];
+                PopulateFormFromExistingSubmission();
+            }
             // For now, existingSubmission stays null.
 
             // TODO: load activityDocuments once detail endpoint is wired:
@@ -405,6 +398,47 @@
         }
     }
 
+    private void PopulateFormFromExistingSubmission()
+    {
+        submissionBody = existingSubmission?.Body ?? string.Empty;
+
+        if (existingSubmission?.Document is not null)
+        {
+            documentUpload = new UploadDocumentValue
+            {
+                Description = existingSubmission.Document.Description ?? string.Empty,
+                ExistingContentType = existingSubmission.Document.ContentType,
+                ExistingFileName = existingSubmission.Document.DisplayName,
+                ExistingDocumentId = existingSubmission.Document.Id,
+                RemoveExistingDocument = false,
+                File = null
+            };
+        }
+        else
+        {
+            documentUpload = new UploadDocumentValue();
+        }
+    }
+
+    private void ToggleEditSubmission()
+    {
+        if (!showResubmitForm)
+        {
+            PopulateFormFromExistingSubmission();
+            formErrors.Clear();
+            errorMessage = null;
+            successMessage = null;
+        }
+
+        showResubmitForm = !showResubmitForm;
+    }
+
+    // private Task OnDocumentChanged(UploadDocumentValue? value)
+    // {
+    //     documentUpload = value ?? new UploadDocumentValue();
+    //     return Task.CompletedTask;
+    // }
+
     // ---- Submit ----
     private async Task SubmitAsync()
     {
@@ -416,43 +450,45 @@
         {
             if (existingSubmission is null)
             {
-                // TODO: replace with real call once ISubmissionService is on the client:
-                // var dto = new CreateSubmissionDto
-                // {
-                //     StudentId  = currentUserId,   // from auth state
-                //     ActivityId = ActivityId,
-                //     Body       = submissionTab == SubmissionTab.Text ? submissionBody : null
-                // };
-                // existingSubmission = await SubmissionService.CreateSubmissionAsync(dto);
-
-                // Optimistic local stand-in
-                existingSubmission = new SubmissionDto
+                var dto = new CreateSubmissionDto
                 {
-                    Id = 0,
-                    StudentId = "current-user",
-                    StudentName = "You",
                     ActivityId = ActivityId,
-                    ActivityName = activity!.Name,
-                    Body = submissionTab == SubmissionTab.Text ? submissionBody : string.Empty,
-                    SubmittedAt = DateTime.Now,
-                    IsLate = isOverdue
+                    Body = submissionBody,
+                    FileDescription = documentUpload.Description
                 };
 
+                errorMessage = null;
+
+                var createdSubmission = await SubmissionService.CreateSubmissionAsync(dto, documentUpload);
+
+                if (createdSubmission is null)
+                {
+                    errorMessage = "Could not create submission.";
+                    return;
+                }
                 successMessage = "Your submission has been recorded! 🎉";
+                existingSubmission = createdSubmission;
             }
             else
             {
-                // TODO: call UpdateSubmissionAsync once wired
-                existingSubmission = existingSubmission with
+                var dto = new UpdateSubmissionDto
                 {
-                    Body = submissionTab == SubmissionTab.Text ? submissionBody : existingSubmission.Body,
-                    SubmittedAt = DateTime.Now
+                    ActivityId = ActivityId,
+                    Body = submissionBody,
+                    FileDescription = documentUpload.Description
                 };
+                var updatedSubmission = await SubmissionService.UpdateSubmissionAsync(existingSubmission.Id, dto, documentUpload);
+                if (updatedSubmission is null)
+                {
+                    errorMessage = "Could not update submission.";
+                    return;
+                }
                 successMessage = "Your submission has been updated.";
+                existingSubmission = updatedSubmission;
             }
 
             showResubmitForm = false;
-            submissionBody = string.Empty;
+            PopulateFormFromExistingSubmission();
         }
         catch (Exception ex)
         {
@@ -469,7 +505,7 @@
     {
         var errors = new Dictionary<string, string>();
 
-        if (submissionTab == SubmissionTab.Text && string.IsNullOrWhiteSpace(submissionBody))
+        if (string.IsNullOrWhiteSpace(submissionBody))
             errors["Body"] = "Please write something before submitting.";
 
         return errors;
@@ -497,6 +533,4 @@
         ActivityType.ELearning => "bg-success",
         _ => "bg-secondary"
     };
-
-    private enum SubmissionTab { Text, File }
 }

--- a/LMS.Blazor/LMS.Blazor.Client/Program.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Program.cs
@@ -25,6 +25,7 @@ internal class Program
         builder.Services.AddScoped<IModuleService, ModuleService>();
         builder.Services.AddScoped<IActivityService, ActivityService>();
         builder.Services.AddScoped<ISubmissionService, SubmissionService>();
+        builder.Services.AddScoped<IDocumentService, DocumentService>();
         builder.Services.AddScoped<IUserService, UserService>();
 
         await builder.Build().RunAsync();

--- a/LMS.Blazor/LMS.Blazor.Client/Program.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Program.cs
@@ -1,6 +1,6 @@
+using BlazorBlueprint.Components;
 using LMS.Blazor.Client.Services;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
-using BlazorBlueprint.Components;
 
 namespace LMS.Blazor.Client;
 
@@ -24,6 +24,7 @@ internal class Program
         builder.Services.AddScoped<ICourseService, CourseService>();
         builder.Services.AddScoped<IModuleService, ModuleService>();
         builder.Services.AddScoped<IActivityService, ActivityService>();
+        builder.Services.AddScoped<ISubmissionService, SubmissionService>();
         builder.Services.AddScoped<IUserService, UserService>();
 
         await builder.Build().RunAsync();

--- a/LMS.Blazor/LMS.Blazor.Client/Services/ClientApiService.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Services/ClientApiService.cs
@@ -53,6 +53,42 @@ public class ClientApiService : IApiService
         return response.IsSuccessStatusCode;
     }
 
+    public async Task<T?> PostMultipartAsync<T>(
+        string endpoint,
+        MultipartFormDataContent content,
+        CancellationToken ct = default)
+    {
+        var response = await _httpClient.PostAsync($"api/proxy/{endpoint}", content, ct);
+        HandleUnauthorized(response);
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(ct);
+            Console.WriteLine(errorBody);
+        }
+        response.EnsureSuccessStatusCode();
+        return await DeserializeAsync<T>(response, ct);
+    }
+
+    public async Task<T?> PutMultipartAsync<T>(
+        string endpoint,
+        MultipartFormDataContent content,
+        CancellationToken ct = default)
+    {
+        var response = await _httpClient.PutAsync($"api/proxy/{endpoint}", content, ct);
+
+        HandleUnauthorized(response);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(ct);
+            Console.WriteLine(errorBody);
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        return await DeserializeAsync<T>(response, ct);
+    }
+
     // -------------------------
     // Private helpers
     // -------------------------
@@ -81,4 +117,6 @@ public class ClientApiService : IApiService
 
         return await JsonSerializer.DeserializeAsync<T>(content, _jsonOptions, ct);
     }
+
+
 }

--- a/LMS.Blazor/LMS.Blazor.Client/Services/DocumentService.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Services/DocumentService.cs
@@ -1,0 +1,153 @@
+﻿using LMS.Blazor.Client.Uploads;
+using LMS.Shared.DTOs.Common;
+using LMS.Shared.DTOs.Document;
+
+namespace LMS.Blazor.Client.Services;
+
+public class DocumentService : IDocumentService
+{
+    private readonly IApiService _apiService;
+    private readonly ILogger<DocumentService> _logger;
+
+    private const string Base = "api/documents";
+
+    public DocumentService(IApiService apiService, ILogger<DocumentService> logger)
+    {
+        _apiService = apiService;
+        _logger = logger;
+    }
+
+    public async Task<PagedResultDto<DocumentDto>?> GetAllDocumentsAsync(
+        int page = 1,
+        int pageSize = 10,
+        DocumentQueryDto? query = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var url = $"{Base}?page={page}&pageSize={pageSize}";
+
+            if (query?.CourseId.HasValue == true)
+                url += $"&courseId={query.CourseId.Value}";
+
+            if (query?.ModuleId.HasValue == true)
+                url += $"&moduleId={query.ModuleId.Value}";
+
+            if (query?.ActivityId.HasValue == true)
+                url += $"&activityId={query.ActivityId.Value}";
+
+            if (query?.SubmissionId.HasValue == true)
+                url += $"&submissionId={query.SubmissionId.Value}";
+
+            return await _apiService.GetAsync<PagedResultDto<DocumentDto>>(url, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching documents.");
+            return null;
+        }
+    }
+
+    public async Task<DocumentDto?> GetDocumentByIdAsync(int id, CancellationToken ct = default)
+    {
+        try
+        {
+            return await _apiService.GetAsync<DocumentDto>($"{Base}/{id}", ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching document {DocumentId}.", id);
+            return null;
+        }
+    }
+
+    public async Task<DocumentDto?> CreateDocumentAsync(
+        CreateDocumentDto dto,
+        UploadDocumentValue? document = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            using var content = BuildCreateDocumentContent(dto, document);
+            return await _apiService.PostMultipartAsync<DocumentDto>(Base, content, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating document.");
+            return null;
+        }
+    }
+
+    public async Task<DocumentDto?> UpdateDocumentAsync(
+        int id,
+        UpdateDocumentDto dto,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            await _apiService.PutAsync<DocumentDto>($"{Base}/{id}", dto, ct);
+            return await GetDocumentByIdAsync(id, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error updating document {DocumentId}.", id);
+            return null;
+        }
+    }
+
+    public async Task DeleteDocumentAsync(int id, CancellationToken ct = default)
+    {
+        try
+        {
+            await _apiService.DeleteAsync($"{Base}/{id}", ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting document {DocumentId}.", id);
+        }
+    }
+
+    public string GetDocumentFileUrl(int id, bool download = false)
+    {
+        return $"/api/proxy/{Base}/{id}/file?download={download.ToString().ToLowerInvariant()}";
+    }
+
+    private static MultipartFormDataContent BuildCreateDocumentContent(
+        CreateDocumentDto dto,
+        UploadDocumentValue? document)
+    {
+        var content = new MultipartFormDataContent();
+
+        if (!string.IsNullOrWhiteSpace(dto.Description))
+        {
+            content.Add(new StringContent(dto.Description), "Description");
+        }
+
+        if (dto.CourseId.HasValue)
+        {
+            content.Add(new StringContent(dto.CourseId.Value.ToString()), "CourseId");
+        }
+
+        if (dto.ModuleId.HasValue)
+        {
+            content.Add(new StringContent(dto.ModuleId.Value.ToString()), "ModuleId");
+        }
+
+        if (dto.ActivityId.HasValue)
+        {
+            content.Add(new StringContent(dto.ActivityId.Value.ToString()), "ActivityId");
+        }
+
+        if (dto.SubmissionId.HasValue)
+        {
+            content.Add(new StringContent(dto.SubmissionId.Value.ToString()), "SubmissionId");
+        }
+
+        if (document is not null)
+        {
+            document.AddToMultipart(content);
+        }
+
+        return content;
+    }
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Services/IApiService.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Services/IApiService.cs
@@ -6,4 +6,6 @@ public interface IApiService
     Task<T?> PostAsync<T>(string endpoint, object body, CancellationToken ct = default);
     Task<T?> PutAsync<T>(string endpoint, object body, CancellationToken ct = default);
     Task<bool> DeleteAsync(string endpoint, CancellationToken ct = default);
+    Task<T?> PostMultipartAsync<T>(string endpoint, MultipartFormDataContent content, CancellationToken ct = default);
+    Task<T?> PutMultipartAsync<T>(string endpoint, MultipartFormDataContent content, CancellationToken ct = default);
 }

--- a/LMS.Blazor/LMS.Blazor.Client/Services/IDocumentService.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Services/IDocumentService.cs
@@ -1,0 +1,30 @@
+﻿using LMS.Blazor.Client.Uploads;
+using LMS.Shared.DTOs.Common;
+using LMS.Shared.DTOs.Document;
+
+namespace LMS.Blazor.Client.Services;
+
+public interface IDocumentService
+{
+    Task<PagedResultDto<DocumentDto>?> GetAllDocumentsAsync(
+        int page = 1,
+        int pageSize = 10,
+        DocumentQueryDto? query = null,
+        CancellationToken ct = default);
+
+    Task<DocumentDto?> GetDocumentByIdAsync(int id, CancellationToken ct = default);
+
+    Task<DocumentDto?> CreateDocumentAsync(
+        CreateDocumentDto dto,
+        UploadDocumentValue? document = null,
+        CancellationToken ct = default);
+
+    Task<DocumentDto?> UpdateDocumentAsync(
+        int id,
+        UpdateDocumentDto dto,
+        CancellationToken ct = default);
+
+    Task DeleteDocumentAsync(int id, CancellationToken ct = default);
+
+    string GetDocumentFileUrl(int id, bool download = false);
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Services/ISubmissionService.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Services/ISubmissionService.cs
@@ -1,0 +1,31 @@
+﻿
+using global::LMS.Blazor.Client.Uploads;
+using global::LMS.Shared.DTOs.Submission;
+using LMS.Shared.DTOs.Common;
+
+namespace LMS.Blazor.Client.Services;
+
+public interface ISubmissionService
+{
+    Task<PagedResultDto<SubmissionDto>?> GetAllSubmissionsAsync(
+        int page = 1,
+        int pageSize = 10,
+        int? activityId = null,
+        string? studentId = null,
+        CancellationToken ct = default);
+
+    Task<SubmissionDto?> GetSubmissionByIdAsync(int id, CancellationToken ct = default);
+
+    Task<SubmissionDto?> CreateSubmissionAsync(
+        CreateSubmissionDto dto,
+        UploadDocumentValue? document = null,
+        CancellationToken ct = default);
+
+    Task<SubmissionDto?> UpdateSubmissionAsync(
+        int submissionId,
+        UpdateSubmissionDto dto,
+        UploadDocumentValue? document = null,
+        CancellationToken ct = default);
+
+    Task DeleteSubmissionAsync(int id, CancellationToken ct = default);
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Services/SubmissionService.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Services/SubmissionService.cs
@@ -1,0 +1,133 @@
+﻿using LMS.Blazor.Client.Uploads;
+using LMS.Shared.DTOs.Common;
+using LMS.Shared.DTOs.Submission;
+
+namespace LMS.Blazor.Client.Services;
+
+public class SubmissionService : ISubmissionService
+{
+    private readonly IApiService _apiService;
+    private readonly ILogger<SubmissionService> _logger;
+
+    private const string Base = "api/submissions";
+
+    public SubmissionService(IApiService apiService, ILogger<SubmissionService> logger)
+    {
+        _apiService = apiService;
+        _logger = logger;
+    }
+
+    public async Task<PagedResultDto<SubmissionDto?>> GetAllSubmissionsAsync(
+        int page = 1,
+        int pageSize = 10,
+        int? activityId = null,
+        string? studentId = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var url = $"{Base}?page={page}&pageSize={pageSize}";
+
+            if (activityId.HasValue)
+                url += $"&activityId={activityId.Value}";
+
+            if (!string.IsNullOrWhiteSpace(studentId))
+                url += $"&studentId={Uri.EscapeDataString(studentId)}";
+
+            return await _apiService.GetAsync<PagedResultDto<SubmissionDto>>(url, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching all submissions.");
+            return null;
+        }
+    }
+
+    public async Task<SubmissionDto?> GetSubmissionByIdAsync(int id, CancellationToken ct = default)
+    {
+        try
+        {
+            return await _apiService.GetAsync<SubmissionDto>($"{Base}/{id}", ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching submission {SubmissionId}.", id);
+            return null;
+        }
+    }
+
+    public async Task<SubmissionDto?> CreateSubmissionAsync(
+        CreateSubmissionDto dto,
+        UploadDocumentValue? document = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            using var content = BuildSubmissionContent(dto, document);
+            return await _apiService.PostMultipartAsync<SubmissionDto>(Base, content, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating submission.");
+            return null;
+        }
+    }
+    public async Task<SubmissionDto?> UpdateSubmissionAsync(
+        int submissionId,
+        UpdateSubmissionDto dto,
+        UploadDocumentValue? document = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            using var content = BuildSubmissionContent(dto, document);
+            await _apiService.PutMultipartAsync<SubmissionDto>($"{Base}/{submissionId}", content, ct);
+            return await GetSubmissionByIdAsync(submissionId, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating submission.");
+            return null;
+        }
+    }
+
+    public async Task DeleteSubmissionAsync(int id, CancellationToken ct = default)
+    {
+        try
+        {
+            await _apiService.DeleteAsync($"{Base}/{id}", ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting submission {SubmissionId}.", id);
+        }
+    }
+
+    private static MultipartFormDataContent BuildSubmissionContent(
+        CreateSubmissionDto dto,
+        UploadDocumentValue? document)
+    {
+        var content = new MultipartFormDataContent();
+
+        var activityIdContent = new StringContent(dto.ActivityId.ToString());
+        content.Add(activityIdContent, "ActivityId");
+
+        if (!string.IsNullOrWhiteSpace(dto.FileDescription))
+        {
+            var fileDescriptionContent = new StringContent(dto.FileDescription.ToString());
+            content.Add(fileDescriptionContent, "FileDescription");
+        }
+        if (!string.IsNullOrWhiteSpace(dto.Body))
+        {
+            var bodyContent = new StringContent(dto.Body);
+            content.Add(bodyContent, "Body");
+        }
+
+        if (document is not null)
+        {
+            document.AddToMultipart(content);
+        }
+
+        return content;
+    }
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Uploads/UploadDocumentExtensions.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Uploads/UploadDocumentExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System.Net.Http.Headers;
+
+namespace LMS.Blazor.Client.Uploads;
+
+public static class UploadDocumentExtensions
+{
+    public static void AddToMultipart(
+        this UploadDocumentValue value,
+        MultipartFormDataContent content)
+    {
+        Console.WriteLine($"AddToMultipart called. HasFile={value.HasFile}, Description='{value.Description}'");
+
+        if (value.File is null)
+        {
+            Console.WriteLine("AddToMultipart: value.File is null.");
+
+            return;
+        }
+
+        var browserFile = value.File.File;
+        Console.WriteLine(
+            $"AddToMultipart: Name={browserFile.Name}, Size={browserFile.Size}, ContentType={browserFile.ContentType}");
+
+
+
+        var stream = browserFile.OpenReadStream(10 * 1024 * 1024);
+
+        var fileContent = new StreamContent(stream);
+        fileContent.Headers.ContentType =
+            new MediaTypeHeaderValue(browserFile.ContentType);
+
+        content.Add(fileContent, "File", browserFile.Name);
+        content.Add(new StringContent(value.Description ?? string.Empty), "FileDescription");
+
+        Console.WriteLine("AddToMultipart: File and FileDescription added to multipart.");
+
+    }
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Uploads/UploadDocumentValue.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Uploads/UploadDocumentValue.cs
@@ -11,8 +11,11 @@ public class UploadDocumentValue
     public string? ExistingFileName { get; set; }
     public string? ExistingContentType { get; set; }
 
+    // flag to use when to delete document, since we don't have proper patch endpoint! (File = null results in no change, not file deletion)
+    // TODO: implement (add RemoveFile flag in UpdateSubmissionDto, so we can call DeleteDocument)
     public bool RemoveExistingDocument { get; set; }
 
     public bool HasFile => File is not null;
     public bool HasExistingDocument => ExistingDocumentId is not null;
+
 }

--- a/LMS.Blazor/LMS.Blazor.Client/Uploads/UploadDocumentValue.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Uploads/UploadDocumentValue.cs
@@ -1,0 +1,18 @@
+﻿using BlazorBlueprint.Components;
+
+namespace LMS.Blazor.Client.Uploads;
+
+public class UploadDocumentValue
+{
+    public FileUploadItem? File { get; set; }
+    public string Description { get; set; } = string.Empty;
+
+    public int? ExistingDocumentId { get; set; }
+    public string? ExistingFileName { get; set; }
+    public string? ExistingContentType { get; set; }
+
+    public bool RemoveExistingDocument { get; set; }
+
+    public bool HasFile => File is not null;
+    public bool HasExistingDocument => ExistingDocumentId is not null;
+}

--- a/LMS.Blazor/LMS.Blazor/Controllers/ProxyController.cs
+++ b/LMS.Blazor/LMS.Blazor/Controllers/ProxyController.cs
@@ -8,6 +8,7 @@ using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 
+[IgnoreAntiforgeryToken]
 [Route("api/proxy")]
 [ApiController]
 [Authorize]
@@ -47,11 +48,11 @@ public class ApiProxyController : ControllerBase
         {
             using var response = await ForwardRequestToApiAsync(client, endpoint, accessToken, ct);
 
-           
+
             if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
                 var newTokens = await TryRefreshTokenAsync(client, userId, ct);
-                if(newTokens == null)
+                if (newTokens == null)
                 {
                     await _tokenStorage.RemoveTokensAsync(userId);
                     return Unauthorized("Token refresh failed");
@@ -68,7 +69,7 @@ public class ApiProxyController : ControllerBase
             return StatusCode(StatusCodes.Status503ServiceUnavailable,
                 "Service unavailable could not reach API");
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             return StatusCode(StatusCodes.Status500InternalServerError, "Internal server error");
         }
@@ -79,7 +80,7 @@ public class ApiProxyController : ControllerBase
         try
         {
             TokenDto? token = await _tokenStorage.GetTokensAsync(userId);
-            if(token == null)
+            if (token == null)
                 return null;
 
             var refreshEndPoint = "api/token/refresh";
@@ -88,7 +89,7 @@ public class ApiProxyController : ControllerBase
 
             var response = await client.PostAsync(refreshEndPoint, content, ct);
 
-            if(!response.IsSuccessStatusCode)
+            if (!response.IsSuccessStatusCode)
                 return null;
 
             var responseContwnt = await response.Content.ReadAsStringAsync(ct);
@@ -97,7 +98,7 @@ public class ApiProxyController : ControllerBase
                 PropertyNameCaseInsensitive = true,
             });
 
-            if(newTokens == null)
+            if (newTokens == null)
                 return null;
 
             await _tokenStorage.StoreTokensAsync(userId, newTokens);
@@ -107,8 +108,6 @@ public class ApiProxyController : ControllerBase
         }
         catch (Exception ex)
         {
-
-            _logger.LogError(ex, "Error refresh tokens for user: {userId}", userId);
             return null;
         }
     }
@@ -134,16 +133,64 @@ public class ApiProxyController : ControllerBase
         return new EmptyResult();
     }
 
-    private async Task<HttpResponseMessage> ForwardRequestToApiAsync(HttpClient client, string endpoint, string accessToken, CancellationToken ct)
+    private async Task<HttpResponseMessage> ForwardRequestToApiAsync(
+    HttpClient client,
+    string endpoint,
+    string accessToken,
+    CancellationToken ct)
     {
         var targetUri = BuildTargetUri(client.BaseAddress!, endpoint);
 
         var requestMessage = new HttpRequestMessage(new HttpMethod(Request.Method), targetUri);
         requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
-        if (Request.ContentLength > 0 || Request.Headers.ContainsKey("Transfer-Encoding"))
+        if (Request.HasFormContentType)
         {
-            requestMessage.Content = new StreamContent(Request.Body);
+            var form = await Request.ReadFormAsync(ct);
+            var multipartContent = new MultipartFormDataContent();
+
+            foreach (var field in form)
+            {
+                foreach (var value in field.Value)
+                {
+                    multipartContent.Add(new StringContent(value), field.Key);
+                }
+            }
+
+            foreach (var file in form.Files)
+            {
+
+                await using var sourceStream = file.OpenReadStream();
+                using var ms = new MemoryStream();
+                await sourceStream.CopyToAsync(ms, ct);
+
+                var fileContent = new ByteArrayContent(ms.ToArray());
+
+                if (!string.IsNullOrWhiteSpace(file.ContentType))
+                {
+                    fileContent.Headers.ContentType =
+                        MediaTypeHeaderValue.Parse(file.ContentType);
+                }
+
+                multipartContent.Add(fileContent, file.Name, file.FileName);
+            }
+
+            requestMessage.Content = multipartContent;
+        }
+        else if (Request.ContentLength > 0 || Request.Headers.ContainsKey("Transfer-Encoding"))
+        {
+            Request.EnableBuffering();
+
+            if (Request.Body.CanSeek)
+                Request.Body.Position = 0;
+
+            using var buffer = new MemoryStream();
+            await Request.Body.CopyToAsync(buffer, ct);
+
+            if (Request.Body.CanSeek)
+                Request.Body.Position = 0;
+
+            requestMessage.Content = new ByteArrayContent(buffer.ToArray());
 
             if (!string.IsNullOrWhiteSpace(Request.ContentType))
             {
@@ -193,7 +240,8 @@ public class ApiProxyController : ControllerBase
             "Authorization",
             "Connection",
             "Content-Length",
-            "Transfer-Encoding"
+            "Transfer-Encoding",
+            "Content-Type"
         };
 
         return skipHeaders.Contains(headerName, StringComparer.OrdinalIgnoreCase);

--- a/LMS.Blazor/LMS.Blazor/LMS.Blazor.csproj
+++ b/LMS.Blazor/LMS.Blazor/LMS.Blazor.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/LMS.Blazor/LMS.Blazor/Services/ServerNoOpApiService.cs
+++ b/LMS.Blazor/LMS.Blazor/Services/ServerNoOpApiService.cs
@@ -29,4 +29,16 @@ public class ServerNoOpApiService(ILogger<ServerNoOpApiService> logger) : IApiSe
         _logger.LogWarning("ServerNoOpApiService called for: {Endpoint}", endpoint);
         return Task.FromResult(false);
     }
+
+    public Task<T?> PostMultipartAsync<T>(string endpoint, MultipartFormDataContent content, CancellationToken ct = default)
+    {
+        _logger.LogWarning("ServerNoOpApiService called for: {Endpoint}", endpoint);
+        return Task.FromResult<T?>(default);
+    }
+
+    public Task<T?> PutMultipartAsync<T>(string endpoint, MultipartFormDataContent content, CancellationToken ct = default)
+    {
+        _logger.LogWarning("ServerNoOpApiService called for: {Endpoint}", endpoint);
+        return Task.FromResult<T?>(default);
+    }
 }

--- a/LMS.Infractructure/Storage/DocumentManager.cs
+++ b/LMS.Infractructure/Storage/DocumentManager.cs
@@ -60,7 +60,7 @@ public class DocumentManager(
         await unitOfWork.CompleteAsync();
     }
 
-    public async Task ReplaceForSubmissionAsync(Submission submission, IFormFile file)
+    public async Task ReplaceForSubmissionAsync(Submission submission, IFormFile file, string? fileDescription)
     {
         ArgumentNullException.ThrowIfNull(submission);
 
@@ -73,7 +73,8 @@ public class DocumentManager(
 
         var document = await CreateEntityAsync(
             submission.StudentId,
-            submissionId: submission.Id);
+            submissionId: submission.Id,
+            description: fileDescription);
 
         await AttachFileAsync(document, file);
 

--- a/LMS.Presentation/Controllers/SubmissionsController.cs
+++ b/LMS.Presentation/Controllers/SubmissionsController.cs
@@ -3,6 +3,7 @@ using LMS.Shared.Request;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Service.Contracts;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -13,9 +14,10 @@ namespace LMS.Presentation.Controllers;
 [Authorize]
 public class SubmissionsController : LmsControllerBase
 {
-
-    public SubmissionsController(IServiceManager serviceManager) : base(serviceManager)
+    private readonly ILogger<SubmissionsController> _logger;
+    public SubmissionsController(IServiceManager serviceManager, ILogger<SubmissionsController> logger) : base(serviceManager)
     {
+        this._logger = logger;
     }
 
     [HttpGet]
@@ -67,10 +69,11 @@ public class SubmissionsController : LmsControllerBase
     [SwaggerResponse(StatusCodes.Status201Created, "Submission created successfully")]
     [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid input")]
     [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden")]
+
     public async Task<IActionResult> CreateSubmission([FromForm] CreateSubmissionDto dto)
     {
-        var submission = await serviceManager.SubmissionService.CreateSubmissionAsync(UserId, dto);
-        return CreatedAtAction(nameof(GetSubmissionById), new { id = submission.Id }, submission);
+        var result = await serviceManager.SubmissionService.CreateSubmissionAsync(UserId, dto);
+        return Ok(result);
     }
 
     [HttpPut("{id}")]

--- a/LMS.Presentation/Controllers/UploadTestController.cs
+++ b/LMS.Presentation/Controllers/UploadTestController.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LMS.Presentation.Controllers;
+
+[ApiController]
+[Route("api/upload-test")]
+[AllowAnonymous]
+public class UploadTestController : ControllerBase
+{
+    [HttpPost]
+    [DisableRequestSizeLimit]
+    public async Task<IActionResult> Post(CancellationToken ct)
+    {
+        var form = await Request.ReadFormAsync(ct);
+        return Ok(new
+        {
+            Keys = form.Keys.ToArray(),
+            FileCount = form.Files.Count,
+            FileName = form.Files.FirstOrDefault()?.FileName,
+            FileLength = form.Files.FirstOrDefault()?.Length
+        });
+    }
+}

--- a/LMS.Services/SubmissionService.cs
+++ b/LMS.Services/SubmissionService.cs
@@ -126,7 +126,7 @@ public class SubmissionService : ISubmissionService
         ArgumentNullException.ThrowIfNull(dto);
         var submission = await GetStudentAccessedSubmission(id, userId);
 
-        await InternallyUpdateSubmissionAsync(submission, dto.Body, dto.ActivityId, dto.File);
+        await InternallyUpdateSubmissionAsync(submission, dto.Body, dto.ActivityId, dto.File, dto.FileDescription);
     }
 
     public async Task UpdateSubmissionPartiallyAsync(int id, string userId, PatchSubmissionDto dto)
@@ -138,15 +138,16 @@ public class SubmissionService : ISubmissionService
         await InternallyUpdateSubmissionAsync(submission,
                                               dto.Body ?? submission.Body ?? string.Empty,
                                               dto.ActivityId ?? submission.Activity.Id,
-                                              dto.File);
+                                              dto.File ?? null,
+                                              dto.FileDescription ?? submission.Document?.Description);
     }
-    private async Task InternallyUpdateSubmissionAsync(Submission submission, string body, int activityId, IFormFile? file)
+    private async Task InternallyUpdateSubmissionAsync(Submission submission, string? body, int? activityId, IFormFile? file, string? fileDescription)
     {
-        submission.Body = body;
-        submission.ActivityId = activityId;
+        submission.Body = body ?? submission.Body;
+        submission.ActivityId = activityId ?? submission.ActivityId;
         if (file != null)
         {
-            await documentManager.ReplaceForSubmissionAsync(submission, file);
+            await documentManager.ReplaceForSubmissionAsync(submission, file, fileDescription);
             return;
         }
 

--- a/LMS.Shared/DTOs/Document/DocumentDto.cs
+++ b/LMS.Shared/DTOs/Document/DocumentDto.cs
@@ -4,7 +4,7 @@
     /// Represents a document attached to a course, module, or activity.
     /// Documents can be associated with one of three scopes: Course, Module, or Activity.
     /// </summary>
-    public record DocumentDto
+    public class DocumentDto
     {
         public required int Id { get; init; }
         /// <summary>
@@ -14,6 +14,7 @@
         public long FileSize { get; init; }
         public required string DisplayName { get; init; }
         public required string Description { get; init; }
+        public required string ContentType { get; init; }
 
         /// <summary>
         /// Date and time when the document was uploaded.

--- a/LMS.Shared/DTOs/Submission/CreateSubmissionDto.cs
+++ b/LMS.Shared/DTOs/Submission/CreateSubmissionDto.cs
@@ -7,10 +7,10 @@ namespace LMS.Shared.DTOs.Submission;
 /// Used in POST /api/submissions requests.
 /// TODO: add file
 /// </summary>
-public record CreateSubmissionDto
+public class CreateSubmissionDto
 {
-    public required int ActivityId { get; init; }
-    public string? Body { get; init; }
-    public IFormFile? File { get; init; } = null!;
-    public string? FileDescription { get; init; }
+    public int ActivityId { get; set; }
+    public string? Body { get; set; }
+    public IFormFile? File { get; set; }
+    public string? FileDescription { get; set; }
 }

--- a/LMS.Shared/DTOs/Submission/PatchSubmissionDto.cs
+++ b/LMS.Shared/DTOs/Submission/PatchSubmissionDto.cs
@@ -11,5 +11,6 @@ public record PatchSubmissionDto
 {
     public int? ActivityId { get; init; }
     public string? Body { get; init; }
-    public IFormFile File { get; init; } = null!;
+    public IFormFile? File { get; init; } = null!;
+    public string? FileDescription { get; init; }
 }

--- a/LMS.Shared/DTOs/Submission/UpdateSubmissionDto.cs
+++ b/LMS.Shared/DTOs/Submission/UpdateSubmissionDto.cs
@@ -1,15 +1,10 @@
-﻿using Microsoft.AspNetCore.Http;
-
-namespace LMS.Shared.DTOs.Submission;
+﻿namespace LMS.Shared.DTOs.Submission;
 
 /// <summary>
 /// Data transfer object for updating an existing submission.
 /// Used in PUT  /api/submissions/{id} requests.
 /// Students can only update their own submissions before the deadline.
 /// </summary>
-public record UpdateSubmissionDto
+public class UpdateSubmissionDto : CreateSubmissionDto
 {
-    public int ActivityId { get; init; }
-    public string Body { get; init; } = string.Empty;
-    public IFormFile File { get; init; } = null!;
 }


### PR DESCRIPTION
## Description
This PR adds end-to-end support for creating and updating submissions with attached files and file descriptions from the Blazor client.

It introduces reusable document upload/download components, adds client services for submissions and documents, extends multipart API support, and updates the proxy to correctly forward multipart form data. It also updates submission and document DTOs to better support file handling and editing existing submissions.