### PR TITLE
Update auth to use username/email

### DIFF
--- a/LMS.Blazor/LMS.Blazor.Client/Layout/NavMenu.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Layout/NavMenu.razor
@@ -109,7 +109,7 @@
                     <div class="nav-item ">
                                     <NavLink class="nav-link" href="/student/overview">
                             <span class="bi bi-grid-nav-menu" aria-hidden="true"></span>
-                            Dashboard
+                            Overview
                         </NavLink>
                     </div>
 

--- a/LMS.Blazor/LMS.Blazor/Components/Account/Pages/Login.razor
+++ b/LMS.Blazor/LMS.Blazor/Components/Account/Pages/Login.razor
@@ -157,7 +157,16 @@
 
             // This doesn't count login failures towards account lockout
             // To enable password failures to trigger account lockout, set lockoutOnFailure: true
-            result = await SignInManager.PasswordSignInAsync(Input.Email, Input.Password, Input.RememberMe, lockoutOnFailure: false);
+            var user = await UserManager.FindByEmailAsync(Input.Email);
+            if (user == null)
+            {
+                errorMessage = "Error: Invalid login attempt!!!!!!!!!.";
+                return;
+            }
+            result = await SignInManager.PasswordSignInAsync(user.UserName!, Input.Password, Input.RememberMe, lockoutOnFailure: false);
+            Console.WriteLine("---------------------------------------");
+            Logger.LogWarning("Login result: Succeeded={S}, IsNotAllowed={NA}, IsLockedOut={L}, Requires2FA={TF}",
+    result.Succeeded, result.IsNotAllowed, result.IsLockedOut, result.RequiresTwoFactor);
         }
 
         if (result.Succeeded)
@@ -167,7 +176,8 @@
             var user = await UserManager.FindByEmailAsync(Input.Email);
             if(user != null)
             {
-                var tokenSuccess = await GetAndStoreJwtTokenAsync(user.Id, Input.Email, Input.Password);
+                // var tokenSuccess = await GetAndStoreJwtTokenAsync(user.Id, Input.Email, Input.Password);
+                var tokenSuccess = await GetAndStoreJwtTokenAsync(user.Id, user.UserName!, Input.Email, Input.Password);
 
                 if (!tokenSuccess)
                 {
@@ -197,17 +207,18 @@
         }
     }
 
-    private async Task<bool> GetAndStoreJwtTokenAsync(string userId, string email, string password)
+    private async Task<bool> GetAndStoreJwtTokenAsync(string userId, string userName, string email, string password)
     {
         try
         {
             var httpClient = HttpClientFactory.CreateClient("LmsApiClient");
 
             var loginRequest = new UserAuthDto
-                {
-                    UserName = email,
-                    Password = password
-                };
+            {
+                UserName = userName,
+                Email = email,
+                Password = password
+            };
 
             var response = await httpClient.PostAsJsonAsync("api/auth/login", loginRequest);
 

--- a/LMS.Blazor/LMS.Blazor/Components/Account/Pages/Register.razor
+++ b/LMS.Blazor/LMS.Blazor/Components/Account/Pages/Register.razor
@@ -40,6 +40,15 @@
                     <ValidationSummary class="text-danger" role="alert" />
 
                     <div class="form-floating mb-3">
+                        <InputText @bind-Value="Input.UserName"
+                                   id="Input.UserName"
+                                   class="form-control"
+                                   placeholder="username" />
+                        <label for="Input.UserName">Username</label>
+                        <ValidationMessage For="() => Input.UserName" class="text-danger" />
+                    </div>
+
+                    <div class="form-floating mb-3">
                         <InputText @bind-Value="Input.Email"
                                    id="Input.Email"
                                    class="form-control"
@@ -116,7 +125,7 @@
     {
         var user = CreateUser();
 
-        await UserStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
+        await UserStore.SetUserNameAsync(user, Input.UserName, CancellationToken.None);
         var emailStore = GetEmailStore();
         await emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
         var result = await UserManager.CreateAsync(user, Input.Password);
@@ -177,6 +186,11 @@
 
     private sealed class InputModel
     {
+        [Required]
+        [Display(Name = "Username")]
+        [StringLength(50, MinimumLength = 3)]
+        public string UserName { get; set; } = "";
+
         [Required]
         [EmailAddress]
         [Display(Name = "Email")]

--- a/LMS.Services/AuthService.cs
+++ b/LMS.Services/AuthService.cs
@@ -3,7 +3,6 @@ using Domain.Models.Configurations;
 using Domain.Models.Entities;
 using Domain.Models.Exceptions;
 using LMS.Shared.DTOs.AuthDtos;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
@@ -14,6 +13,7 @@ using System.Security.Cryptography;
 using System.Text;
 
 namespace LMS.Services;
+
 public class AuthService : IAuthService
 {
     private readonly IMapper mapper;
@@ -132,7 +132,7 @@ public class AuthService : IAuthService
     {
         ArgumentNullException.ThrowIfNull(userDto);
 
-        user = await userManager.FindByNameAsync(userDto.UserName);
+        user = await userManager.FindByEmailAsync(userDto.Email);
 
         return user != null && await userManager.CheckPasswordAsync(user, userDto.Password);
     }

--- a/LMS.Shared/DTOs/AuthDtos/UserAuthDto.cs
+++ b/LMS.Shared/DTOs/AuthDtos/UserAuthDto.cs
@@ -1,10 +1,15 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
 namespace LMS.Shared.DTOs.AuthDtos;
+
 public record UserAuthDto
 {
     [Required]
     public string UserName { get; init; } = string.Empty;
+
+    [Required]
+    [EmailAddress]
+    public string Email { get; init; } = string.Empty;
 
     [Required]
     public string Password { get; init; } = string.Empty;


### PR DESCRIPTION
Update auth to use username/email and improve registration

Refactor login to authenticate by email, passing both username and email for JWT token retrieval. Add username field to registration with validation. Update AuthService to validate users by email. Enhance UserAuthDto with email property. Minor UI and error message improvements.