### PR TITLE
Update Modules.razor

### DIFF
--- a/LMS.Blazor/LMS.Blazor.Client/Pages/Modules.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/Modules.razor
@@ -155,7 +155,11 @@
         }
     }
 
-    private void ToggleRole() => isTeacher = !isTeacher;
+    private void ToggleRole() 
+    {
+        isTeacher = !isTeacher;
+        isDialogOpen = false;
+    }
     private void CycleGradient(int id) => gradientIndex[id] = (gradientIndex.GetValueOrDefault(id, id % ModuleStyles.Gradients.Length) + 1) % ModuleStyles.Gradients.Length;
     
     private void GoToModule(int id) =>


### PR DESCRIPTION
Update the ToggleRole method to reset the isDialogOpen state to false.
This ensures that if a user opens the dialog as a Teacher, then switches to Student, the state is cleared before they switch back to Teacher.